### PR TITLE
[feat] 색상 토큰 global.css에 추가

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,10 +1,6 @@
 @import "tailwindcss";
 
 :root {
-  /* base */
-  --color-white: #ffffff;
-  --color-black: #000000;
-
   /* background */
   --color-bg-default: #f6f7f9;
 


### PR DESCRIPTION
## 📌 작업 내용

> 무엇을 구현/수정했는지 간단 요약
프로젝트에 사용되는 색상을 CSS 변수 기반 컬러 토큰으로 정의

## 🔍 주요 변경 사항
- tailwind v4 방식에 맞춰서 global.css에 컬러 토큰 정의  
- primmary 컬러를 브랜드 컬러로 분리 
- 디자인에 사용된 남색과 하늘색 accent 컬러 
- 회색 2컬러  
- 퀴즈 난이도 상/중/하 배경, 텍스트 색상
- 페이지 배경 색상


## 🧪 테스트 방법

> 리뷰어가 해당 과정만 보고 테스트가 가능하도록 자세히 작성해주세요.
- 기존에 만들고 있던 페이지에 색상 `bg-[var(--color-primary)]
`로 변수로 지정했을 때 반영되는 거 확인 

## ⚠️ 리뷰 시 참고 사항
- 기존 tailwind v4의 css-first 방식에 맞춰 tailwind.config.ts파일에 저장하지 않고 진행  

## 👀 결과 화면

> 스크린샷 (필요시)

## 📝 관련 이슈

- closes #21
