### PR TITLE
[chore] pr 생성 시, slack에 자동으로 메시지를 전달하는 workflow 추가

### DIFF
--- a/.github/workflows/notify-pr-to-slack.yml
+++ b/.github/workflows/notify-pr-to-slack.yml
@@ -31,7 +31,7 @@ jobs:
 
           payload=$(cat <<EOF
           {
-            "text": "📝 *PR 생성 알림* \n - *작성자* : ${PR_CREATOR} \n - *제목* : ${PR_TITLE}${LABELS_TEXT}\n - *브랜치* : ${COMPARE_BRANCH} → ${BASE_BRANCH} \n \n - *링크* : ${PR_URL}"
+            "text": "📝 *PR 생성 알림* \n * `${PR_CREATOR}`* 님이 PR을 생성하였어요. \n \n - *제목* : ${PR_TITLE}${LABELS_TEXT}\n - *브랜치* : `${COMPARE_BRANCH}` → `${BASE_BRANCH}` \n - *링크* : ${PR_URL}"
           }
           EOF
           )


### PR DESCRIPTION
## 📌 작업 내용

- 개발 편의성을 위해서, slack 채널로 자동으로 전달되도록 설정

## 🔍 주요 변경 사항
- github actions 의 secret에 slack web hook 주소 추가
- workflows .yml 파일 추가

### 작동 조건
- PR 생성 시마다 PR 생성 알림이 채널로 전달됩니다.


## 🧪 테스트 방법
-

## ⚠️ 리뷰 시 참고 사항
정리
https://www.notion.so/Slack-GitHub-PR-2b5fc6c6670180809632d10639e49515?source=copy_link

## 👀 결과 화면

<img width="401" height="125" alt="image" src="https://github.com/user-attachments/assets/ab724d12-c066-4a0e-af52-d2716ea2e711" />

## 📝 관련 이슈

closes #50 
