### PR TITLE
[chore] SSL 인증서 발급 및 적용

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,8 @@ services:
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       # - ./nginx/ssl:/etc/nginx/ssl:ro
+      - /srv/letsencrypt/www:/var/www/certbot
+      - /srv/letsencrypt/conf:/etc/letsencrypt
     depends_on:
       - frontend
       - backend

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,30 +1,52 @@
-
 events {
-    worker_connections 1024;
+  worker_connections 1024;
 }
 
 http {
-    upstream front {
-        server frontend:3000;
+  upstream front {
+    server frontend:3000;
+  }
+
+  upstream back {
+    server backend:8080;
+  }
+
+  # HTTP(80): 인증서 검증 + HTTPS로 리다이렉트
+  server {
+    listen 80;
+    server_name csbbokbbok.duckdns.org;
+
+    location /.well-known/acme-challenge/ {
+      root /var/www/certbot;
     }
 
-    upstream back {
-        server backend:8080;
+    location / {
+      return 301 https://$host$request_uri;
+    }
+  }
+
+  # HTTPS(443): 실제 서비스
+  server {
+    listen 443 ssl;
+    server_name csbbokbbok.duckdns.org;
+
+    ssl_certificate /etc/letsencrypt/live/csbbokbbok.duckdns.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/csbbokbbok.duckdns.org/privkey.pem;
+
+    location / {
+      proxy_pass http://front;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto https;
     }
 
-    server {
-        listen 80;
-
-        location / {
-            proxy_pass http://front;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-        }
-
-        location /api/ {
-            proxy_pass http://back;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-        }
+    location /api/ {
+      proxy_pass http://back;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto https;
     }
+  }
 }


### PR DESCRIPTION
## 📌 작업 내용

> 무엇을 구현/수정했는지 간단 요약

- Let’s Encrypt 기반 SSL 인증서 발급
- nginx.conf 수정: HTTPS 적용을 위한 Nginx 설정 수정
- docker-compose.yml 수정: 도커 환경에서 인증서 적용되도록, Nginx 컨테이너에 볼륨(`/srv/letsencrypt`)을 마운트하도록 설정 추가

## 🔍 주요 변경 사항

- 도메인 등록: `csbbokbbok.duckdns.org` 등록

- Let’s Encrypt 기반 SSL 인증서 발급

- `nginx/nginx.conf`
    - `/.well-known/acme-challenge/` 경로 정적 서빙 설정 추가 (인증서 발급 및 갱신시 사용)
    - `80 → 443` 리다이렉트 설정 추가
    - `443 ssl` 서버 블록 추가 및 인증서 경로 연결
    - 아침 회의에서 혜린님이 말씀하셨던 옵션 추가
   
    ```bash
          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
          proxy_set_header X-Forwarded-Proto https;
    ```
    
- `docker-compose.yml`
    - Let’s Encrypt 인증서/챌린지 파일을 위한 볼륨 마운트 추가
        - `/srv/letsencrypt/www → /var/www/certbot`
        - `/srv/letsencrypt/conf → /etc/letsencrypt`

## 🧪 테스트 방법

> 리뷰어가 해당 과정만 보고 테스트가 가능하도록 자세히 작성해주세요.
- `https://csbbokbbok.duckdns.org/` 접속하여 마이크 권한 획득 확인

## ⚠️ 리뷰 시 참고 사항

- 원래는 NCP의 certificate manager를 활용하여 인증서를 발급 받아 설정하고 있었는데, 최종적으로 적용하려면 로드밸런서를 추가해야한다고 합니다.
- 로드밸런서는 유료이기도 하고 현재 웹서버가 1대뿐이어서 로드밸런서 구성은 필요하지 않을 것 같았습니다. 그래서 석찬님이 아침 회의에서 말씀하셨던, 서버에서 설치할 수 있는 SSL 인증서를 발급받아서 등록했습니다.
- 해당 인증서는 90일마다 갱신이 필요하다고 하여 프로젝트 기간동안 충분하긴 하지만 혹시 몰라서 매일 3시에 인증서 갱신 시도하도록 crontab을 등록했습니다. (root 계정)
 

## 👀 결과 화면

> 스크린샷 (필요시)

- `https://csbbokbbok.duckdns.org/` 접속하여 마이크 권한 획득 가능 확인
<img width="704" height="461" alt="image" src="https://github.com/user-attachments/assets/5d19ec4d-e724-462c-81b2-d788d1513265" />


## 📝 관련 이슈

closes #59 
