### PR TITLE
[test] quizzes.service.ts 테스트 pass하도록 수정

### DIFF
--- a/backend/src/modules/quizzes/quizzes.service.spec.ts
+++ b/backend/src/modules/quizzes/quizzes.service.spec.ts
@@ -2,6 +2,27 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { NotFoundException } from '@nestjs/common';
 import { QuizzesService } from './quizzes.service';
 import { MainQuizRepository } from '../../datasources/repositories/tb-main-quiz.repository';
+import {
+  MainQuiz,
+  DifficultyLevel,
+} from '../../datasources/entities/tb-main-quiz.entity';
+import { ChecklistItem } from '../../datasources/entities/tb-checklist-item.entity';
+
+const createMockQuiz = (overrides?: Partial<MainQuiz>): MainQuiz => {
+  return {
+    mainQuizId: 1,
+    title: '테스트 퀴즈',
+    content: '테스트 내용',
+    hint: '테스트 힌트',
+    difficultyLevel: DifficultyLevel.EASY,
+    quizCategory: { quizCategoryId: 1, name: '운영체제' },
+    checklistItems: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    created_by: 1,
+    ...overrides,
+  } as MainQuiz;
+};
 
 describe('QuizzesService', () => {
   let service: QuizzesService;
@@ -9,15 +30,19 @@ describe('QuizzesService', () => {
 
   beforeEach(async () => {
     const mockRepository = {
-      findOneWithChecklist: jest.fn(),
+      find: jest.fn().mockResolvedValue([]),
+      getCategoriesWithCount: jest.fn().mockResolvedValue([]),
+      count: jest.fn().mockResolvedValue(0),
+      findById: jest.fn().mockResolvedValue(null),
+      findOneWithChecklist: jest.fn().mockResolvedValue(null),
     };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         QuizzesService,
         {
-          provide: MainQuizRepository, // 실제 Repository 대신
-          useValue: mockRepository, // Mock으로 대체
+          provide: MainQuizRepository,
+          useValue: mockRepository,
         },
       ],
     }).compile();
@@ -26,28 +51,110 @@ describe('QuizzesService', () => {
     repository = module.get(MainQuizRepository);
   });
 
+  describe('getQuizzes', () => {
+    it('필터 조건 없이 모든 퀴즈를 반환한다', async () => {
+      const mockQuizzes = [createMockQuiz()];
+      repository.find.mockResolvedValue(mockQuizzes);
+
+      const result = await service.getQuizzes();
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(repository.find).toHaveBeenCalled();
+      expect(result).toEqual(mockQuizzes);
+    });
+
+    it('카테고리와 난이도로 필터링하여 조회한다', async () => {
+      repository.find.mockResolvedValue([]);
+
+      await service.getQuizzes('운영체제', DifficultyLevel.EASY);
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(repository.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          where: expect.objectContaining({
+            quizCategory: { name: '운영체제' },
+            difficultyLevel: DifficultyLevel.EASY,
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('getCategoriesWithCount', () => {
+    it('카테고리별 개수와 전체 개수를 반환한다', async () => {
+      repository.getCategoriesWithCount.mockResolvedValue([
+        { id: '1', name: '네트워크', count: '5' },
+      ]);
+      repository.count.mockResolvedValue(10);
+
+      const result = await service.getCategoriesWithCount();
+
+      expect(result.totalCount).toBe(10);
+      expect(result.categories[0].id).toBe(1);
+      expect(result.categories[0].count).toBe(5);
+    });
+  });
+
+  describe('findOne', () => {
+    it('ID로 퀴즈를 조회한다', async () => {
+      const mockQuiz = createMockQuiz();
+      repository.findById.mockResolvedValue(mockQuiz);
+
+      const result = await service.findOne(1);
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(repository.findById).toHaveBeenCalledWith(1);
+      expect(result).toEqual(mockQuiz);
+    });
+
+    it('퀴즈가 없으면 undefined를 반환한다', async () => {
+      repository.findById.mockResolvedValue(null);
+
+      const result = await service.findOne(999);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
   describe('getQuizChecklist', () => {
     it('퀴즈가 존재하지 않으면 NotFoundException을 던진다', async () => {
-      // Given
       repository.findOneWithChecklist.mockResolvedValue(null);
 
-      // When & Then
       await expect(service.getQuizChecklist(999)).rejects.toThrow(
-        new NotFoundException('해당 퀴즈를 찾을 수 없습니다.'),
+        NotFoundException,
       );
     });
 
-    it('퀴즈와 체크리스트를 정상적으로 반환한다', async () => {
-      // Given
+    it('체크리스트가 없으면 NotFoundException을 던진다', async () => {
+      const quizWithNoChecklist = createMockQuiz({ checklistItems: [] });
+      repository.findOneWithChecklist.mockResolvedValue(quizWithNoChecklist);
 
-      // When
+      await expect(service.getQuizChecklist(1)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('정상적인 체크리스트를 반환한다', async () => {
+      const mockChecklistItem = {
+        checklistItemId: 1,
+        content: '체크1',
+        sortOrder: 1,
+        mainQuizId: 1,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as unknown as ChecklistItem;
+
+      const quizWithChecklist = createMockQuiz({
+        checklistItems: [mockChecklistItem],
+      });
+
+      repository.findOneWithChecklist.mockResolvedValue(quizWithChecklist);
+
       const result = await service.getQuizChecklist(1);
 
-      // Then
-      expect(result.mainQuizId).toBe(1);
-      expect(result.title).toBe('테스트 퀴즈');
-      expect(result.checklistItems).toHaveLength(2);
       expect(result.checklistItems[0].checklistItemId).toBe(1);
+      expect(result.title).toBe('테스트 퀴즈');
     });
   });
 });


### PR DESCRIPTION
## 📌 작업 내용

> 무엇을 구현/수정했는지 간단 요약

QuizzesService가 기존의 Mock Data 방식에서 실제 TypeORM Repository를 사용하는 방식으로 리팩토링됨에 따라, quizzes.service.spec.ts를 수정했습니다. 

기존 테스트 코드는 서비스가 리포지토리의 메서드를 호출할 때 "그런 함수 없다"고 에러를 발생시키고 있어서 Mock Repository의 정의를 업데이트하고 타입 안전성을 확보했습니다.

## 📝 주요 변경 사항
- Mock Repository 메서드 최신화
  - QuizzesService에서 실제로 사용하는 find, getCategoriesWithCount, count, findById 메서드를 jest.fn()으로 정의하고 기본 반환값을 설정했습니다.

- 테스트 데이터 생성 헬퍼 함수 추가 (createMockQuiz)
  - 테스트마다 중복되는 Mock 데이터 생성을 줄이고, any 타입 사용을 지양하기 위해 Partial<MainQuiz>를 활용한 안전한 객체 생성 함수를 구현했습니다.

- 린트(Lint) 에러 해결
  - Unsafe assignment of any value 및 Unbound method 등 Jest와 ESLint 충돌로 발생하는 에러를 해결하기 위해 적절한 타입 단언(as unknown as ...)과 예외 처리 주석을 추가했습니다.

- 테스트 케이스 보강
  - 필터링 조회: 카테고리와 난이도 조건이 있을 때 find가 올바른 파라미터로 호출되는지 검증했습니다.
  
  - 예외 처리: 퀴즈는 존재하지만 체크리스트가 비어있는 경우 NotFoundException이 발생하는 케이스를 추가했습니다.