### PR TITLE
[fix] 카메라 옵션 설정 문제 수정

### DIFF
--- a/frontend/src/app/main-quiz/[id]/components/AudioRecorder.tsx
+++ b/frontend/src/app/main-quiz/[id]/components/AudioRecorder.tsx
@@ -365,11 +365,11 @@ export default function AudioRecorder({ quizId }: AudioRecorderProps) {
               <div className="text-sm font-medium text-gray-800">카메라</div>
               <select
                 className="w-full rounded-xl border border-gray-200 bg-white px-3 py-4 pr-10 text-sm appearance-none cursor-pointer"
-                value={selectedMicId}
-                onChange={(e) => setSelectedMicId(e.target.value)}
+                value={selectedVideoId}
+                onChange={(e) => setSelectedVideoId(e.target.value)}
                 disabled={recordStatus === 'recording' || isSubmitting}
               >
-                {micOptions.map((opt, idx) => (
+                {videoOptions.map((opt, idx) => (
                   <option key={`${opt.value}-${idx}`} value={opt.value}>
                     {opt.label}
                   </option>


### PR DESCRIPTION
## 📌 작업 내용

> 무엇을 구현/수정했는지 간단 요약

- 카메라 옵션 설정 오류 해결

## 🔍 주요 변경 사항

- 기존 카메라 선택 옵션 처리를 해주는 부분이 마이크 옵션 및 마이크 설정으로 구현되어 있어 해당 부분을 카메라 옵션 설정으로 수정했습니다.


## 🧪 테스트 방법

> 리뷰어가 해당 과정만 보고 테스트가 가능하도록 자세히 작성해주세요.

말하기 답변 페이지 접속하여 비디오 권한 설정 후, 카메라 옵션을 선택합니다.

## ⚠️ 리뷰 시 참고 사항

## 👀 결과 화면

> 스크린샷 (필요시)
- 권한 미동의
<img width="1082" height="483" alt="스크린샷 2026-01-15 오후 11 56 04" src="https://github.com/user-attachments/assets/3092c109-1b57-443b-b654-43a7655fd0a3" />

- 권한 동의
<img width="1048" height="516" alt="스크린샷 2026-01-15 오후 11 56 21" src="https://github.com/user-attachments/assets/78feb170-9916-4e12-97b3-b0e7c6b8926e" />


## 📝 관련 이슈

> (예시) closes #<이슈번호> 

closes #111 
