### PR TITLE
[hotfix] CLOVA speech 호출시 result가 COMPLETED가 아닐 경우 로깅 추가

### DIFF
--- a/backend/src/modules/speeches/speeches.service.ts
+++ b/backend/src/modules/speeches/speeches.service.ts
@@ -366,7 +366,10 @@ export class SpeechesService {
         );
 
         // 일별 한도 제한 초과 오류 (CLOVA가 response.ok && body.result=FAILED 으로 응답함)
-        if (result.message?.includes('일별 한도')) {
+        if (
+          result.result === 'FAILED' &&
+          result.message?.includes('일별 한도')
+        ) {
           throw new BusinessException(
             ERROR_MESSAGES.EXTERNAL_API_DAILY_QUOTA_EXCEEDED,
           );


### PR DESCRIPTION
## 📌 작업 내용

> 무엇을 구현/수정했는지 간단 요약

- CLOVA speech 호출시
  - response.ok 이면서 CLOVA 응답 body의 result 값이 COMPLETED가 아닐 경우에도 로깅 추가
  - 이전 hotfix에서 반영한 catch{} 내부의 logExternalApiError 위치 다시 원복 -> 이중 로깅 방지

## 🔍 주요 변경 사항

## 🧪 테스트 방법

> 리뷰어가 해당 과정만 보고 테스트가 가능하도록 자세히 작성해주세요.

## ⚠️ 리뷰 시 참고 사항

## 👀 결과 화면

> 스크린샷 (필요시)

## 📝 관련 이슈

> (예시) closes #12
