### PR TITLE
[style] pretendart 폰트 적용

### DIFF
--- a/backend/src/modules/quizzes/quizzes.service.spec.ts
+++ b/backend/src/modules/quizzes/quizzes.service.spec.ts
@@ -339,7 +339,7 @@ describe('QuizzesService', () => {
     });
 
     it('유저가 존재하면 중요도별로 분류된 퀴즈 데이터를 반환한다', async () => {
-      const mockUser: DeepPartial<User> = { userId: 1, email: 'test@test.com' };
+      const mockUser: DeepPartial<User> = { userId: 1 };
       userRepository.findById.mockResolvedValue(mockUser as User);
 
       const mockSolvedQuizzes: DeepPartial<SolvedQuiz>[] = [
@@ -413,7 +413,7 @@ describe('QuizzesService', () => {
     });
 
     it('푼 퀴즈 중, 중요도가 설정된 퀴즈가 없으면 빈 배열들을 반환한다', async () => {
-      const mockUser: DeepPartial<User> = { userId: 1, email: 'test@test.com' };
+      const mockUser: DeepPartial<User> = { userId: 1 };
       userRepository.findById.mockResolvedValue(mockUser as User);
 
       solvedQuizRepository.getImportanceByUserId.mockResolvedValue([]);

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2,10 +2,6 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
 @custom-variant dark (&:is(.dark *));
 
 :root {


### PR DESCRIPTION
## 📌 작업 내용

> 무엇을 구현/수정했는지 간단 요약

- pretendart 폰트 적용했습니다.  
## 🔍 주요 변경 사항

- globals.css에 Pretendard 공식 저장소에서 가장 많이 사용되는 dynamic subset 방식을 적용했습니다.  
- globals.css의 @layer base에서 html 태그에 font-family를 지정하여
프로젝트 전반에 Pretendard 폰트가 일괄 적용되도록 설정했습니다.  

-[참고자료](https://github.com/orioncactus/pretendard)  

## 🧪 테스트 방법

> 리뷰어가 해당 과정만 보고 테스트가 가능하도록 자세히 작성해주세요.

## ⚠️ 리뷰 시 참고 사항
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/ede0f8e9-de9a-4837-9fbf-88b6b860f8af" />  

- 자고 일어나 확인해보니, Tailwind v4에서 @tailwind base와 @tailwind components가 공식적으로 제거되면서 관련 문법 오류가 발생하고 있습니다.  
Tailwind v4에서는 base 레이어가 @import "tailwindcss/preflight"로 대체되었고, components 레이어는 아예 삭제되어 더 이상 기본 스타일을 자동으로 깔아주지 않는 정책으로 바뀌었습니다. 그래서 기존 v3 문법을 그대로 쓰면 IntelliSense와 빌드에서 에러가 발생하고, 단순히 preflight + utilities로 바꾸면 폰트, 버튼, 입력 요소 등 기존 디자인이 많이 깨지고 있습니다.  
현재 프로젝트 Tailwind 버전은 4.1.18로 설치되어 있습니다.  
v3로 다시 설치해서 기존 globals.css를 그대로 사용하거나
v4 구조에 맞춰 globals.css를 수정하여 base 스타일을 직접 추가하고, components 레이어에 의존하던 스타일들을 수동으로 복구하는 방법이 있습니다.  
일단 AI를 활용해서 v4에 맞게 기본 base 스타일을 추가해보았지만, 디자인이 깨지는 문제가 있어 추가로 방법을 고민하고 있습니다.
팀원분들도 참고 부탁드립니다.  

### 해결
- 처음에 globals.css에서 폰트를 적용하기 위해 @tailwind base; @tailwind components; @tailwind utilities;를 넣으라는 가이드를 확인했는데, 이는 Tailwind v3 기준 문법이었습니다. v3에서는 base/components 레이어가 html/body 기본 스타일, 버튼/입력 요소 스타일, keyframes 등을 자동으로 제공했기 때문에 Tailwind를 정상적으로 사용하려면 3줄을 반드시 넣어야 했습니다.  
- 그런데 저희 프로젝트의 Tailwind 버전은 v4여서 @import "tailwindcss/preflight"; @tailwind utilities;로 바꾸라는 에러가 발생했습니다. v4에서는 preflight가 브라우저 기본 스타일만 reset하고 utilities는 유틸리티 클래스만 활성화하기 때문에, v3처럼 base/components가 자동으로 제공하던 폰트, 버튼, input 스타일 등이 포함되지 않아 디자인이 깨지는 문제가 있었습니다. 그래서 AI가 base 스타일을 직접 추가하라고 안내한 것이었습니다.  
- 하지만 다시 확인해보니, v4에서는 @import "tailwindcss" 한 줄만으로 theme, preflight(base), utilities가 모두 자동 주입됩니다. 따라서 폰트 적용만이 목적이라면 @tailwind base/components/utilities나 별도의 preflight/utilities import 모두 필요 없었습니다. Pretendard 다이나믹 서브셋 url과 @layer base에서 폰트 설정만 해주면 폰트가 정상적으로 적용됩니다.  


<img width="1000" alt="image" src="https://github.com/user-attachments/assets/eb119801-5e63-4472-a7e5-9a193127ae1f" />


## 👀 결과 화면

> 스크린샷 (필요시) 
- 전  
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/146c2688-f3ac-4c6e-a1f7-c7132107e8d5" />

- 후  
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/2445a33e-edc1-40a0-95bb-d56b53d8dcf3" />

## 📝 관련 이슈

> (예시) closes #12
- closes #186 
