### PR TITLE
[fix] 중요도 저장 시, 풀이 상태를 업데이트 한다

### DIFF
--- a/backend/src/datasources/repositories/tb-solved-quiz.repository.ts
+++ b/backend/src/datasources/repositories/tb-solved-quiz.repository.ts
@@ -1,6 +1,10 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { DeepPartial, Repository, DataSource } from 'typeorm';
-import { SolvedQuiz, Importance } from '../entities/tb-solved-quiz.entity';
+import {
+  SolvedQuiz,
+  Importance,
+  SolvedState,
+} from '../entities/tb-solved-quiz.entity';
 import { UpdateResult } from 'typeorm/browser';
 import { InjectRepository } from '@nestjs/typeorm';
 import { z } from 'zod';
@@ -121,6 +125,17 @@ export class SolvedQuizRepository {
     importance: Importance,
   ): Promise<UpdateResult> {
     return await this.repository.update(solvedQuizId, { importance });
+  }
+
+  async updateImportanceAndSolvedState(
+    solvedQuizId: number,
+    importance: Importance,
+    solvedState: SolvedState,
+  ): Promise<UpdateResult> {
+    return await this.repository.update(solvedQuizId, {
+      importance,
+      solvedState,
+    });
   }
 
   async getImportanceByUserId(userId: number): Promise<SolvedQuiz[]> {

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -17,6 +17,7 @@ import { ERROR_MESSAGES } from '../../common/constants/error-messages';
 import { SolvedQuizRepository } from 'src/datasources/repositories/tb-solved-quiz.repository';
 import { BusinessException } from '../../common/exceptions/business.exception';
 import { MAX_USER_ANSWER_LENGTH } from 'src/common/constants/speech.constant';
+import { SolvedState } from 'src/datasources/entities/tb-solved-quiz.entity';
 
 @Injectable()
 export class UsersService {
@@ -131,10 +132,12 @@ export class UsersService {
       );
     }
 
-    const result = await this.solvedQuizRepository.updateImportance(
-      solvedQuizId,
-      importance,
-    );
+    const result =
+      await this.solvedQuizRepository.updateImportanceAndSolvedState(
+        solvedQuizId,
+        importance,
+        SolvedState.COMPLETED,
+      );
 
     // 처리 중 삭제 등으로 인해 실제로 업데이트된 행이 없는 경우 방어
     if (result.affected !== 1) {


### PR DESCRIPTION
## 📌 작업 내용

> 무엇을 구현/수정했는지 간단 요약

- 중요도 저장 시, 풀이상태가 업데이트 된다.

## 🔍 주요 변경 사항

- 기존 중요도 저장 api 로직에 중요도와 함께 solvedSate = "COMPLELTED"로 변경되도록 수정했습니다.

## 🧪 테스트 방법

> 리뷰어가 해당 과정만 보고 테스트가 가능하도록 자세히 작성해주세요.

## ⚠️ 리뷰 시 참고 사항

## 👀 결과 화면

> 스크린샷 (필요시)

## 📝 관련 이슈

> (예시) closes #<이슈번호>

closes #193 
