### PR TITLE
[fix] 퀴즈 선택 요소 변경

### DIFF
--- a/frontend/src/app/quizzes/components/QuizTypeSelectPopup.tsx
+++ b/frontend/src/app/quizzes/components/QuizTypeSelectPopup.tsx
@@ -25,14 +25,6 @@ export default function QuizTypeSelectPopup({ quiz, isOpen, onClose }: QuizTypeS
         router.push(`/main-quiz/${quiz.mainQuizId}/multiple-choice`);
         break;
 
-      case QUIZ_ENTRY_MODES.SUBJECTIVE:
-        alert(MESSAGES.NOT_IMPLEMENTED);
-        break;
-
-      case QUIZ_ENTRY_MODES.BOTH:
-        alert(MESSAGES.NOT_IMPLEMENTED);
-        break;
-
       case QUIZ_ENTRY_MODES.SKIP:
         router.push(`/main-quiz/${quiz.mainQuizId}`);
         break;
@@ -56,7 +48,10 @@ export default function QuizTypeSelectPopup({ quiz, isOpen, onClose }: QuizTypeS
           </p>
         </div>
 
-        <div className="grid grid-cols-4 gap-8" onClick={(e) => e.stopPropagation()}>
+        <div
+          className="grid grid-cols-2 gap-8 justify-items-center"
+          onClick={(e) => e.stopPropagation()}
+        >
           {QUIZ_TYPE_OPTIONS.map((o) => (
             <button
               key={o.key}

--- a/frontend/src/constants/quizzes.constant.ts
+++ b/frontend/src/constants/quizzes.constant.ts
@@ -10,8 +10,6 @@ export type QuizEntryMode = (typeof QUIZ_ENTRY_MODES)[keyof typeof QUIZ_ENTRY_MO
 
 export const QUIZ_TYPE_OPTIONS = [
   { key: QUIZ_ENTRY_MODES.MULTIPLE, title: '객관식', desc: '객관식 퀴즈 풀고나서 메인퀴즈 풀기' },
-  { key: QUIZ_ENTRY_MODES.SUBJECTIVE, title: '주관식', desc: '주관식 퀴즈 풀고나서 메인퀴즈 풀기' },
-  { key: QUIZ_ENTRY_MODES.BOTH, title: '모두', desc: '객관식 및 주관식을 풀고 메인퀴즈' },
   { key: QUIZ_ENTRY_MODES.SKIP, title: '메인퀴즈', desc: '몸풀기 퀴즈 없이 바로 시작' },
 ] as const;
 


### PR DESCRIPTION
## 📌 작업 내용

> 무엇을 구현/수정했는지 간단 요약

- 퀴즈 선택 요소 변경

## 🔍 주요 변경 사항
- 기존 객관식/주관식/둘다/말하기 퀴즈 옵션으로 구성되어있던 요소를 주관식 퀴즈를 제외함으로써 객관식/말하기 퀴즈 옵션만 남기고 제외했습니다.

## 🧪 테스트 방법

> 리뷰어가 해당 과정만 보고 테스트가 가능하도록 자세히 작성해주세요.

- 퀴즈 목록 접속하기
- 말하기 퀴즈 시작하기
- 시작 전, 퀴즈 옵션 선택 화면 확인

## ⚠️ 리뷰 시 참고 사항

## 👀 결과 화면

> 스크린샷 (필요시)

<img width="1921" height="992" alt="스크린샷 2026-01-28 오전 3 33 20" src="https://github.com/user-attachments/assets/3f4c4f97-8c2b-4b98-a784-948497131465" />

## 📝 관련 이슈

> (예시) closes

#198 
