### PR TITLE
[fix] middleware 추가를 통한 인증 및 권한 부여

### DIFF
--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -13,7 +13,7 @@ export function middleware(request: NextRequest) {
 
   // 미인증 사용자가 로그인 및 리포트 페이지 접근 시
   if (!isAuthenticated && request.nextUrl.pathname.startsWith('/user')) {
-    return NextResponse.redirect(new URL('/', request.url));
+    return NextResponse.redirect(new URL('/?error=auth_required', request.url));
   }
 
   return NextResponse.next();


### PR DESCRIPTION
## 📌 작업 내용

> 무엇을 구현/수정했는지 간단 요약

Next에서 제공하는 middleware를 활용하여 사용자의 인증 여부에 따른 페이지 리다이렉트 로직 구현했습니다.

## 🔍 주요 변경 사항
- `middleware.ts` 파일 추가
  - 해당 로직에서 accessToken을 쿠키에서 가져와 인증 정보가 존재할 경우 / 페이지를 요청할 때 /quizzes로 리다이렉트 되도록 했습니다.
  - 또한, 미인증된 사용자(게스트)인 경우 /user(리포트 페이지)를 요청할 때 로그인 페이지로 리다이렉트 되도록 설정했습니다.

- 동작 흐름
```
사용자 요청
    ↓
[Next.js Middleware]
    → 액세스 토큰만 체크
    → 있으면 통과, 없으면 로그인으로
    ↓
[페이지 렌더링]
```
## 🧪 테스트 방법

> 리뷰어가 해당 과정만 보고 테스트가 가능하도록 자세히 작성해주세요.

1. 로그인 상태
- 로그인 상태에서 / 페이지로 접속 요청을 보냅니다.
- /페이지가 아닌 /quizzes로 리다이렉트 되는 것 확인

2. 비로그인 상태
- 비 로그인 상태에서 / 페이지로 접속 시, 로그인 페이지에 접속됩니다.
- /user로 요청하는 경우 로그인이 필요한 서비스로 로그인페이지로 리다이렉트 됩니다. 

## ⚠️ 리뷰 시 참고 사항

공식문서를 참고했습니다.
https://nextjs-ko.org/docs/app/building-your-application/routing/middleware

## 👀 결과 화면

> 스크린샷 (필요시)

## 📝 관련 이슈

> (예시) closes #<이슈번호>

closes #209 
