### PR TITLE
fix: ai 피드백 실패시, 재제출이 안되는 오류 해결

### DIFF
--- a/backend/src/datasources/repositories/tb-user-checklist-progress.repository.ts
+++ b/backend/src/datasources/repositories/tb-user-checklist-progress.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { QueryDeepPartialEntity, Repository } from 'typeorm';
 import { UserChecklistProgress } from '../entities/tb-user-checklist-progress.entity';
 
 @Injectable()
@@ -47,9 +47,12 @@ export class UserChecklistProgressRepository {
         isChecked: item.isChecked,
         checkedAt: item.isChecked ? new Date() : null,
       }),
-    );
+    ) as QueryDeepPartialEntity<UserChecklistProgress>[];
 
-    await this.repository.save(entities);
+    await this.repository.upsert(entities, {
+      conflictPaths: ['user', 'checklistItem', 'solvedQuiz'],
+      skipUpdateIfNoValuesChanged: true,
+    });
   }
 
   // solved quiz의 체크리스트를 가져온다


### PR DESCRIPTION
## 📌 작업 내용

AI 피드백 생성 실패 후 **재시도 시 DB 에러가 발생하는 문제**를 해결했습니다.

---

## 🔍 주요 변경 사항

### 1. 현재 문제

<img width="1014" height="62" alt="image" src="https://github.com/user-attachments/assets/c5015709-2b2a-49da-975e-642186a1d702" />

AI 피드백 요청이 실패한 뒤 다시 제출하면,
위와 같은 DB 오류가 발생하며 **재제출이 되지 않는 문제**가 있었습니다.

---

### 2. 문제 원인 파악

현재 처리 흐름은 다음과 같습니다.

```
1. AI 피드백 제출
   - 요청 1: AI 피드백 생성 및 저장
   - 요청 2: solved quiz 저장
2. 서버에서 요청 1 실패, 요청 2 성공
3. 사용자가 AI 피드백을 다시 제출
4. 이전 요청 2에서 이미 entity가 저장되어 있어 중복 오류 발생
```

AI 피드백 생성은 오류로 실패했지만,
요청 2의 solved quiz 데이터 저장은 정상적으로 완료되어 DB에 저장되었습니다.

이 상태에서 AI 피드백을 다시 제출하면
**동일한 solved quiz 저장 요청이 다시 전달**되며, 이미 있는 데이터라고 중복 오류가 발생합니다.
이는 현재 저장 로직이 typeORM의 `save()`로 되어 있어 발생하는 것입니다.

```ts
async saveUserChecklistProgress(...): Promise<void> {
  ...
  await this.repository.save(entities);
}
```

---

### 3. 해결 방안

고려한 해결 방안은 다음 3가지입니다.

1. AI 피드백만 다시 제출하여 페이지를 넘기는 방식
2. solved quiz 데이터 저장 방식을 `update`로 변경
3. AI 피드백 생성과 solved quiz 저장을 하나의 요청으로 합치고 `transactional`로 묶기

1번과 3번 방식은 구현 범위가 크고 수정할 부분이 많아,
**2번 방식으로 수정하기로 결정**했습니다.

2번 방식을 적용하는 방법은 다음 두 가지가 있습니다.

* `save()`를 사용하되, TypeORM이 `update`로 인식할 수 있도록 처리
* TypeORM의 `upsert()` 사용

---

### 4. 구현

`TypeORM`의 `save()` 함수는 내부적으로 insert와 update를 자동으로 선택합니다.
(이미 데이터가 존재한다고 판단되면 `update` 수행)

하지만 이번 문제의 원인은
**TypeORM이 해당 데이터를 `update` 대상으로 인식하지 못했기 때문**입니다.

TypeORM은 **PK 기준으로 데이터 존재 여부를 판단**합니다.
현재 코드에서는 PK를 명시하지 않았기 때문에,
TypeORM은 항상 새로운 데이터로 인식하여 insert를 시도하고,
그 결과 UNIQUE 제약조건에 위배되어 DB 에러가 발생했습니다.

PK를 명시하면 문제를 해결할 수 있습니다.

```ts
const entities = checklistItems.map((item) =>
  this.repository.create({
    // 여기에 PK 값을 명시하면 해결 가능
    user: { userId },
    checklistItem: { checklistItemId: item.checklistItemId },
    solvedQuiz: { solvedQuizId },
    isChecked: item.isChecked,
    checkedAt: item.isChecked ? new Date() : null,
  }),
);
```

다만,

* 한 번에 여러 entity를 처리하는 구조이고
* PK를 찾기 위해 추가적인 조회가 필요하며
* 성능상 불리한 부분이 있어

`save()` 대신 **`upsert()` 방식으로 수정**하였습니다.

---

## 🧪 테스트 방법

AI 피드백 실패 상황을 재현하기 위해
`feedback.service`의 `generateAIFeedback` 함수에서 강제로 예외를 발생시켜 테스트했습니다.

이후 AI 피드백을 다시 제출했을 때,
정상적으로 요청이 처리되는 것을 확인했습니다.

---

## ⚠️ 리뷰 시 참고 사항

(없음)

---

## 👀 결과 화면

(생략)

---

## 📝 관련 이슈

* closes #206

---