### PR TITLE
[refactor] 말하기 연습 녹음시 불필요한 리렌더링 개선

### DIFF
--- a/frontend/src/app/main-quiz/[id]/components/Recorder.tsx
+++ b/frontend/src/app/main-quiz/[id]/components/Recorder.tsx
@@ -46,6 +46,7 @@ export default function Recorder({ quizId, onSwitchToTextMode }: AudioRecorderPr
   const [isVideoRecording, setIsVideoRecording] = useState(false);
   const [error, setError] = useState<string>('');
   const [isPopupOpen, setIsPopupOpen] = useState(false);
+  const [isTimeoutPopupOpen, setIsTimeoutPopupOpen] = useState(false);
 
   const { audioUrl, audioBlob, audioManifest, startRecording, stopRecording, resetRecording } =
     useAudioRecorder({
@@ -323,6 +324,19 @@ export default function Recorder({ quizId, onSwitchToTextMode }: AudioRecorderPr
     }
   };
 
+  const handleTimeout = async () => {
+    setIsTimeoutPopupOpen(true);
+    await handleStop();
+  };
+
+  const handleTimeoutConfirm = () => {
+    setIsTimeoutPopupOpen(false);
+    setMessage(
+      `녹음 시간(${MAX_SPEECH_SECONDS}초)을 초과했습니다. 녹음 내용을 확인한 후 다시 녹음해주세요.`,
+    );
+    // 여기서 바로 handleRetry()하면 사용자가 녹음 파일을 확인 할 수 없으므로 handleRetry()하지 않음
+  };
+
   const actionButtons = useRecordActionButtons({
     recordStatus,
     canRecord,
@@ -334,12 +348,6 @@ export default function Recorder({ quizId, onSwitchToTextMode }: AudioRecorderPr
   });
 
   const isSubmitting = recordStatus === 'submitting';
-
-  const handleTimeout = async () => {
-    const errMsg = `녹음 시간(${MAX_SPEECH_SECONDS}초)을 초과했습니다. 다시 녹음해주세요.`;
-    alert(errMsg);
-    await handleStop();
-  };
 
   return (
     <div>
@@ -437,6 +445,13 @@ export default function Recorder({ quizId, onSwitchToTextMode }: AudioRecorderPr
         description="녹음중인 답변이 제출되지 않습니다."
         onConfirm={handleConfirm}
         onCancel={handleCancel}
+      />
+      <Popup
+        isOpen={isTimeoutPopupOpen}
+        title="녹음 시간이 초과되었습니다."
+        description={`녹음 시간(${MAX_SPEECH_SECONDS}초)을 초과했습니다. 녹음 내용을 확인한 후 다시 녹음해주세요.`}
+        confirmText="확인"
+        onConfirm={handleTimeoutConfirm}
       />
     </div>
   );

--- a/frontend/src/app/main-quiz/[id]/components/Recorder.tsx
+++ b/frontend/src/app/main-quiz/[id]/components/Recorder.tsx
@@ -17,6 +17,7 @@ import { useRecordActionButtons } from '@/hooks/mainQuiz/useRecordActionButtons'
 import RecordedVideo from './record/RecordedVideo';
 import Popup from '@/components/Popup';
 import RecorderTimerContainer from './RecorderTimerContainer';
+import { MAX_SPEECH_SECONDS } from '@/constants/speech.constants';
 interface AudioRecorderProps {
   quizId: number;
   onSwitchToTextMode: () => void;
@@ -335,7 +336,7 @@ export default function Recorder({ quizId, onSwitchToTextMode }: AudioRecorderPr
   const isSubmitting = recordStatus === 'submitting';
 
   const handleTimeout = async () => {
-    const errMsg = '녹음 시간(3분)을 초과했습니다. 다시 녹음해주세요.';
+    const errMsg = `녹음 시간(${MAX_SPEECH_SECONDS}초)을 초과했습니다. 다시 녹음해주세요.`;
     alert(errMsg);
     await handleStop();
   };

--- a/frontend/src/app/main-quiz/[id]/components/RecorderTimerContainer.tsx
+++ b/frontend/src/app/main-quiz/[id]/components/RecorderTimerContainer.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useRecorderTimer } from '@/hooks/mainQuiz/useRecorderTimer';
+import RecorderTimer from './RecorderTimer';
+
+type Props = {
+  isRecording: boolean;
+  onTimeout: () => void;
+};
+
+export default function RecorderTimerContainer({ isRecording, onTimeout }: Props) {
+  const timer = useRecorderTimer();
+  const hasTimedOutRef = useRef(false);
+
+  useEffect(() => {
+    if (isRecording === true) {
+      timer.startTimer();
+      return () => {
+        timer.stopTimer();
+      };
+    }
+
+    // 녹음 종료시 다음 녹음을 위해 타이머 상태 초기화
+    hasTimedOutRef.current = false;
+    timer.resetTimer();
+  }, [isRecording, timer.startTimer, timer.stopTimer, timer.resetTimer]);
+
+  useEffect(() => {
+    if (isRecording === false) {
+      return;
+    }
+
+    if (timer.isMaximumTime === false) {
+      return;
+    }
+
+    if (hasTimedOutRef.current === true) {
+      return;
+    }
+
+    hasTimedOutRef.current = true;
+    onTimeout();
+  }, [isRecording, timer.isMaximumTime, onTimeout]);
+
+  return (
+    <RecorderTimer
+      seconds={timer.seconds}
+      maxSeconds={timer.maxSeconds}
+      isRecording={isRecording}
+    />
+  );
+}

--- a/frontend/src/components/Popup.tsx
+++ b/frontend/src/components/Popup.tsx
@@ -7,7 +7,7 @@ interface PopupProps {
   confirmText?: string;
   cancelText?: string;
   onConfirm: () => void;
-  onCancel: () => void;
+  onCancel?: () => void;
 }
 
 function Popup({
@@ -38,14 +38,16 @@ function Popup({
 
         {/* 버튼 영역 */}
         <div className="flex gap-5">
-          <Button
-            variant="secondary"
-            size="cta"
-            className="flex-1 rounded-[20px]"
-            onClick={onCancel}
-          >
-            {cancelText}
-          </Button>
+          {onCancel && (
+            <Button
+              variant="secondary"
+              size="cta"
+              className="flex-1 rounded-[20px]"
+              onClick={onCancel}
+            >
+              {cancelText}
+            </Button>
+          )}
 
           <Button
             variant="primary"

--- a/frontend/src/constants/speech.constants.ts
+++ b/frontend/src/constants/speech.constants.ts
@@ -1,2 +1,3 @@
 export const MAX_SPEECH_TEXT_LENGTH = 1500; // 말하기 연습 답변 최대 글자수 제한 (3분 기준 1200자 내외 + 버퍼 300자)
 export const MIN_SPEECH_TEXT_LENGTH = 50; // 말하기 연습 답변 최소 글자수 제한
+export const MAX_SPEECH_SECONDS = 180; // 말하기 연습 시간 제한

--- a/frontend/src/hooks/mainQuiz/useRecorderTimer.ts
+++ b/frontend/src/hooks/mainQuiz/useRecorderTimer.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-
-const MAX_SECONDS = 120;
+import { MAX_SPEECH_SECONDS } from '@/constants/speech.constants';
 
 export function useRecorderTimer() {
   const [seconds, setSeconds] = useState(0);
@@ -11,7 +10,7 @@ export function useRecorderTimer() {
 
     intervalRef.current = setInterval(() => {
       setSeconds((prev) => {
-        if (prev >= MAX_SECONDS) {
+        if (prev >= MAX_SPEECH_SECONDS) {
           return prev;
         }
         return prev + 1;
@@ -39,10 +38,10 @@ export function useRecorderTimer() {
 
   return {
     seconds,
-    isMaximumTime: seconds >= MAX_SECONDS,
+    isMaximumTime: seconds >= MAX_SPEECH_SECONDS,
     startTimer,
     stopTimer,
     resetTimer,
-    maxSeconds: MAX_SECONDS,
+    maxSeconds: MAX_SPEECH_SECONDS,
   };
 }


### PR DESCRIPTION
## 📌 작업 내용

> 무엇을 구현/수정했는지 간단 요약

- 말하기 연습 페이지의 Recorder에서 타이머 상태 업데이트로 인해 상위 컴포넌트가 반복 리렌더링되는 문제 개선
- 타이머 로직을 `RecorderTimerContainer`로 분리하여 타이머 영역만 리렌더링되도록 범위 축소

## 🔍 주요 변경 사항

#### [FE] Recorder 타이머 컨테이너 분리로 리렌더링 범위 축소
- 경로: `frontend/src/app/main-quiz/[id]/components/RecorderTimerContainer.tsx`
- `useRecorderTimer()` 호출 위치를 `Recorder`에서 분리하여 RecorderTimer 컨테이너로 이동
- 타이머 1초 tick에 따른 리렌더링이 `Recorder` 전체가 아닌 타이머 UI 영역에만 발생하도록 개선
- 최대 녹음 시간 도달 시 `onTimeout`콜백을 통해 녹음 중지/안내 처리를 상위에서 수행할 수 있도록 연결

#### [FE] Recorder에서 타이머 의존 로직 제거
- 경로: `frontend/src/app/main-quiz/[id]/components/Recorder.tsx`
- 기존 `useRecorderTimer` 사용 및 제한시간 감지용 `useEffect` 제거
- 타이머 UI(`RecorderTimer`)는 `RecorderTimerContainer`를 통해 렌더링하도록 변경

#### [FE] 말하기 제한 시간 120초 -> 180초 변경
- 경로:
  - `frontend/src/constants/speech.constants.ts`
  - `frontend/src/hooks/mainQuiz/useRecorderTimer.ts`
- 아침 회의 내용 반영

#### [FE] 말하기 시간 제한시간 초과시 공통 팝업 알림
- 경로: 
  - `frontend/src/app/main-quiz/[id]/components/Recorder.tsx`
  - `frontend/src/components/Popup.tsx`
- UI 개선을 위해 기존 alret 으로 알리던 제한 시간 초과 알림을 제거하고 공통 팝업 적용
- onConfirm 버튼만 존재하는 팝업을 활용 가능하도록, 공통 팝업의 onCancel버튼을 optional로 수정


## 🧪 테스트 방법

> 리뷰어가 해당 과정만 보고 테스트가 가능하도록 자세히 작성해주세요.

1. 말하기 연습 페이지 진입
    - 경로: `/main-quiz/[id]` (예: `/main-quiz/1`)
2. 마이크 권한을 허용하고 [말하기] 버튼 클릭 → 녹음 시작
3. 타이머가 1초 단위로 증가하는지 확인
4. React DevTools Profiler로 확인
  - 녹음 중에도 `Recorder` 전체가 1초마다 리렌더되지 않고, 타이머/버튼 등 필요한 영역만 리렌더되는지 확인
5. 녹음 제한 시간 도달 시 동작 확인
  - 자동으로 녹음이 중지되고, 안내 메시지/처리가 정상적으로 동작하는지 확인

## ⚠️ 리뷰 시 참고 사항

- `RecorderTimerContainer`는 타이머 엔진(`useRecorderTimer`)을 캡슐화하고, 상위(`Recorder`)에는 시간 초과 이벤트만 전달하도록 구현했습니다.


## 👀 결과 화면

> 스크린샷 (필요시)

- 말하기 제한 시간(180초) 초과시 팝업
- <img width="504" height="365" alt="image" src="https://github.com/user-attachments/assets/6b1e7852-c85f-4bf0-b952-317715d3b9d2" />


## 📝 관련 이슈

closes #237 
