### PR TITLE
[fix] AT 만료 후에 접속한 사용자 상태 반영

### DIFF
--- a/backend/src/common/constants/auth.constants.ts
+++ b/backend/src/common/constants/auth.constants.ts
@@ -1,0 +1,11 @@
+// 토큰 만료 시간 (JWT용)
+export const ACCESS_TOKEN_EXPIRES_IN = '1h';
+export const REFRESH_TOKEN_EXPIRES_IN = '7d';
+
+// 쿠키 만료 시간 (밀리초)
+export const ACCESS_TOKEN_MAX_AGE = 60 * 60 * 1000; // 1시간
+export const REFRESH_TOKEN_MAX_AGE = 7 * 24 * 60 * 60 * 1000; // 7일
+export const USERNAME_COOKIE_MAX_AGE = ACCESS_TOKEN_MAX_AGE; // AT와 동일
+
+// Redis TTL (초)
+export const REFRESH_TOKEN_TTL = 60 * 60 * 24 * 7; // 7일

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -5,6 +5,11 @@ import { TestLoginDto } from './dto/test-login.dto';
 import type { Response, Request } from 'express';
 import { BusinessException } from 'src/common/exceptions/business.exception';
 import { ERROR_MESSAGES } from 'src/common/constants/error-messages';
+import {
+  ACCESS_TOKEN_MAX_AGE,
+  REFRESH_TOKEN_MAX_AGE,
+  USERNAME_COOKIE_MAX_AGE,
+} from 'src/common/constants/auth.constants';
 import { Public } from './decorator/public.decorator';
 import { clearGuestUserIdCookie } from './utils/guest-user.util';
 @Controller('auth')
@@ -24,14 +29,14 @@ export class AuthController {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',
-      maxAge: 7 * 24 * 60 * 60 * 1000,
+      maxAge: REFRESH_TOKEN_MAX_AGE,
     });
 
     res.cookie('accessToken', accessToken, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',
-      maxAge: 60 * 60 * 1000,
+      maxAge: ACCESS_TOKEN_MAX_AGE,
     });
 
     // UI 표시용으로 사용될 username
@@ -39,7 +44,7 @@ export class AuthController {
       httpOnly: false,
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',
-      maxAge: 60 * 60 * 1000,
+      maxAge: USERNAME_COOKIE_MAX_AGE,
     });
 
     // 게스트 쿠키 삭제
@@ -66,21 +71,21 @@ export class AuthController {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',
-      maxAge: 7 * 24 * 60 * 60 * 1000,
+      maxAge: REFRESH_TOKEN_MAX_AGE,
     });
 
     res.cookie('accessToken', accessToken, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',
-      maxAge: 60 * 60 * 1000,
+      maxAge: ACCESS_TOKEN_MAX_AGE,
     });
 
     res.cookie('username', user.username, {
       httpOnly: false,
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',
-      maxAge: 60 * 60 * 1000,
+      maxAge: USERNAME_COOKIE_MAX_AGE,
     });
 
     clearGuestUserIdCookie(res);
@@ -106,21 +111,21 @@ export class AuthController {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',
-      maxAge: 7 * 24 * 60 * 60 * 1000,
+      maxAge: REFRESH_TOKEN_MAX_AGE,
     });
 
     res.cookie('accessToken', newTokens.accessToken, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',
-      maxAge: 60 * 60 * 1000,
+      maxAge: ACCESS_TOKEN_MAX_AGE,
     });
 
     res.cookie('username', newTokens.username, {
       httpOnly: false,
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',
-      maxAge: 60 * 60 * 1000,
+      maxAge: USERNAME_COOKIE_MAX_AGE,
     });
     return { success: true };
   }

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -116,6 +116,12 @@ export class AuthController {
       maxAge: 60 * 60 * 1000,
     });
 
+    res.cookie('username', newTokens.username, {
+      httpOnly: false,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: 60 * 60 * 1000,
+    });
     return { success: true };
   }
 

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -39,7 +39,7 @@ export class AuthController {
       httpOnly: false,
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',
-      maxAge: 7 * 24 * 60 * 60 * 1000,
+      maxAge: 60 * 60 * 1000,
     });
 
     // 게스트 쿠키 삭제
@@ -80,7 +80,7 @@ export class AuthController {
       httpOnly: false,
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',
-      maxAge: 7 * 24 * 60 * 60 * 1000,
+      maxAge: 60 * 60 * 1000,
     });
 
     clearGuestUserIdCookie(res);

--- a/backend/src/modules/auth/auth.module.ts
+++ b/backend/src/modules/auth/auth.module.ts
@@ -9,6 +9,7 @@ import { JwtStrategy } from './strategies/jwt.strategy';
 import { JwtAuthGuard } from './guard/jwt-auth.guard';
 import { TokenRefreshMiddleware } from './middleware/token-refresh.middleware';
 import { NestModule, MiddlewareConsumer } from '@nestjs/common';
+import { ACCESS_TOKEN_EXPIRES_IN } from 'src/common/constants/auth.constants';
 
 @Module({
   imports: [
@@ -20,7 +21,7 @@ import { NestModule, MiddlewareConsumer } from '@nestjs/common';
       inject: [ConfigService],
       useFactory: (configService: ConfigService) => ({
         secret: configService.get<string>('JWT_SECRET'),
-        signOptions: { expiresIn: '1h' },
+        signOptions: { expiresIn: ACCESS_TOKEN_EXPIRES_IN },
       }),
     }),
   ],

--- a/backend/src/modules/auth/auth.module.ts
+++ b/backend/src/modules/auth/auth.module.ts
@@ -7,6 +7,8 @@ import { PassportModule } from '@nestjs/passport';
 import { DatasourcesModule } from 'src/datasources/datasources.module';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { JwtAuthGuard } from './guard/jwt-auth.guard';
+import { TokenRefreshMiddleware } from './middleware/token-refresh.middleware';
+import { NestModule, MiddlewareConsumer } from '@nestjs/common';
 
 @Module({
   imports: [
@@ -23,7 +25,11 @@ import { JwtAuthGuard } from './guard/jwt-auth.guard';
     }),
   ],
   controllers: [AuthController],
-  providers: [AuthService, JwtStrategy, JwtAuthGuard],
+  providers: [AuthService, JwtStrategy, JwtAuthGuard, TokenRefreshMiddleware],
   exports: [AuthService, JwtAuthGuard],
 })
-export class AuthModule {}
+export class AuthModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(TokenRefreshMiddleware).forRoutes('*');
+  }
+}

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -199,7 +199,12 @@ export class AuthService {
     }
 
     // 새 토큰 발급
-    return this.issueTokens(uuid);
+    const tokens = await this.issueTokens(uuid);
+    const user = await this.userRepository.findByUuid(uuid);
+    if (!user) {
+      throw new BusinessException(ERROR_MESSAGES.USER_NOT_FOUND);
+    }
+    return { ...tokens, username: user.username };
   }
 
   // 토큰 발급 및 Redis 저장

--- a/backend/src/modules/auth/middleware/token-refresh.middleware.ts
+++ b/backend/src/modules/auth/middleware/token-refresh.middleware.ts
@@ -20,13 +20,11 @@ export class TokenRefreshMiddleware implements NestMiddleware {
 
     // RT가 없으면 갱신 불가
     if (!refreshToken) {
-      console.log('RT 없음 → 진행');
       return next();
     }
 
     // AT가 없거나 만료된 경우
     if (!accessToken || this.isAccessTokenExpired(accessToken)) {
-      console.log('AT 없거나 만료 → 갱신 시도');
       try {
         const newTokens =
           await this.authService.refreshAccessTokenOnly(refreshToken);

--- a/backend/src/modules/auth/middleware/token-refresh.middleware.ts
+++ b/backend/src/modules/auth/middleware/token-refresh.middleware.ts
@@ -1,0 +1,68 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import { JwtService } from '@nestjs/jwt';
+import { AuthService } from '../auth.service';
+
+@Injectable()
+export class TokenRefreshMiddleware implements NestMiddleware {
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly authService: AuthService,
+  ) {}
+
+  async use(req: Request, res: Response, next: NextFunction) {
+    const accessToken = req.cookies['accessToken'];
+    const refreshToken = req.cookies['refreshToken'];
+
+    // RT가 없으면 갱신 불가
+    if (!refreshToken) {
+      console.log('RT 없음 → 진행');
+      return next();
+    }
+
+    // AT가 없거나 만료된 경우
+    if (!accessToken || this.isAccessTokenExpired(accessToken)) {
+      console.log('AT 없거나 만료 → 갱신 시도');
+      try {
+        const newTokens =
+          await this.authService.refreshAccessTokenOnly(refreshToken);
+        // 새 쿠키 설정
+        this.setTokenCookies(res, newTokens);
+        // 현재 요청의 쿠키 업데이트
+        req.cookies['accessToken'] = newTokens.accessToken;
+      } catch {
+        // refresh 실패 시 기존 흐름 진행
+      }
+    }
+
+    return next();
+  }
+
+  private setTokenCookies(
+    res: Response,
+    tokens: { accessToken: string; username: string },
+  ) {
+    res.cookie('accessToken', tokens.accessToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: 60 * 60 * 1000, // 1시간
+    });
+
+    res.cookie('username', tokens.username, {
+      httpOnly: false,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: 60 * 60 * 1000, // 1시간
+    });
+  }
+
+  private isAccessTokenExpired(token: string): boolean {
+    try {
+      this.jwtService.verify(token);
+      return false;
+    } catch (err) {
+      return err.name === 'TokenExpiredError';
+    }
+  }
+}

--- a/backend/src/modules/auth/middleware/token-refresh.middleware.ts
+++ b/backend/src/modules/auth/middleware/token-refresh.middleware.ts
@@ -2,6 +2,10 @@ import { Injectable, NestMiddleware } from '@nestjs/common';
 import { Request, Response, NextFunction } from 'express';
 import { JwtService } from '@nestjs/jwt';
 import { AuthService } from '../auth.service';
+import {
+  ACCESS_TOKEN_MAX_AGE,
+  USERNAME_COOKIE_MAX_AGE,
+} from 'src/common/constants/auth.constants';
 
 @Injectable()
 export class TokenRefreshMiddleware implements NestMiddleware {
@@ -46,14 +50,14 @@ export class TokenRefreshMiddleware implements NestMiddleware {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',
-      maxAge: 60 * 60 * 1000, // 1시간
+      maxAge: ACCESS_TOKEN_MAX_AGE,
     });
 
     res.cookie('username', tokens.username, {
       httpOnly: false,
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',
-      maxAge: 60 * 60 * 1000, // 1시간
+      maxAge: USERNAME_COOKIE_MAX_AGE,
     });
   }
 

--- a/frontend/src/services/http/apiFetch.ts
+++ b/frontend/src/services/http/apiFetch.ts
@@ -77,6 +77,7 @@ export async function apiFetch<T>(
         credentials: 'include',
       });
     } catch (refreshError) {
+      document.cookie = 'username=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT';
       throw new ApiError('세션이 만료되었습니다. 다시 로그인해주세요.', 401, 'TOKEN_EXPIRED');
     }
   }


### PR DESCRIPTION
## 📌 작업 내용

> 무엇을 구현/수정했는지 간단 요약

- Access Token(AT) 만료 후에도 Header에 로그인 상태로 표시되던 문제 해결
- RT가 유효한 상태에서 AT가 만료되었을 때 자동 갱신되지 않고 게스트로 전환되던 문제 해결 

## 🔍 주요 변경 사항
### 1. username 쿠키 만료 시간 동기화

- 기존에 useAuth에서 로그인 상태를 판단할 때 JS로 접근 가능한 쿠키는 username뿐이었다.  
- 문제: username 쿠키의 만료 기한이 7일이었는데 accessToken의 만료 기한은 1시간이라서, AT가 만료되어도 username은 남아있어 Header에는 로그인 상태로 표시되었다.  
- 해결: username 쿠키의 만료 시간을 accessToken과 동일하게 1시간으로 변경하여 동기화했다.   

### 2. refresh 실패 시 쿠키 정리

- 문제: refresh가 실패했을 때 에러만 throw하고 쿠키를 정리하는 로직이 없어서, refresh 실패 후에도 Header에 로그인 상태로 보일 수 있었다.  
- 해결: refresh 실패 시 username 쿠키를 제거하는 로직을 추가했다.  


### 3.  refresh 시 username 쿠키 갱신

- 문제: 기존 refresh 로직에서 AT와 RT는 갱신하지만 username 쿠키는 갱신하지 않았다. AT 만료 시 username도 함께 만료되므로 갱신이 필요했다.  
- 해결: refresh 시 username 쿠키도 함께 갱신하도록 수정했다.  

### 4. 백엔드 토큰 자동 갱신 미들웨어 추가  

- 문제: @Public() 라우트에서는 AT가 만료되어도 401이 발생하지 않아 프론트엔드의 refresh 로직이 트리거되지 않았다. 그 결과 로그인 사용자가 게스트로 전환되는 문제가 발생했다.  
```
문제 흐름 요약
1. AT 만료됨 (1시간 경과)
2. 사용자가 퀴즈 제출 (speeches API 호출)
3. @Public() 라우트라서 401 에러가 발생하지 않음
4. Guard가 토큰 검증 실패해도 그냥 통과시킴
5. user가 null로 컨트롤러에 전달됨
6. getOrCreateGuestUserId() 호출 → 게스트 유저 생성
7. 기존 로그인 사용자의 데이터와 분리됨
```    

- 미들웨어, 가드, 인터셉터 중에서 미들웨어를 선택했다.  
  - 가드: 기존 로직을 활용할 수 있지만, 인증/인가라는 가드의 본래 역할과 다르므로 책임 분리 위반  
  - 인터셉터: Guard 이후에 실행되므로 이미 user가 null로 설정된 상태에서는 토큰을 갱신해도 해당 요청에 반영할 수 없음  
  - 미들웨어: Guard 실행 전에 토큰을 갱신할 수 있어 새 토큰으로 인증이 가능하고, 토큰 갱신(미들웨어) / 인증·인가(가드)로 책임 분리 가능    

```
해결한 흐름
1. Request 수신
2. cookie-parser 미들웨어
3. TokenRefreshMiddleware 
   - AT 만료 확인
   - RT가 유효하면 새 토큰 발급
   - req.cookies['accessToken'] 업데이트
4. JwtAuthGuard
   - 새 AT로 검증 성공
   - req.user에 사용자 정보 설정
5. Controller
   - user가 정상적으로 전달됨 (로그인 상태 유지)
```  

- refreshAccessTokenOnly 메서드를 별도로 정의한 이유: 기존 refresh 메서드는 RT Rotation(Refresh Token도 함께 갱신)을 수행한다. 이 경우 동시에 여러 API 요청이 발생하면, 첫 번째 요청이 RT를 갱신하여 Redis를 업데이트하고, 나머지 요청들은 이전 RT로 시도하여 Redis와 불일치가 발생해 모두 실패하는 문제가 있었다. 따라서 미들웨어에서는 AT만 갱신하고 RT는 유지하여 동시 요청 문제를 해결했다.    
- catch 블록에서 별도 처리를 하지 않은 이유: refreshAccessTokenOnly에서 예외를 throw하면 catch로 잡히는데, 이때 별도로 처리하지 않고 다음으로 진행시킨다. refresh가 실패했다면 기존 흐름대로 진행되어 @Public() 라우트는 게스트로, 일반 라우트는 401로 처리되도록 의도했기 때문이다.  

### 5. 프론트엔드 refresh 로직 유지  

- @Public() 데코레이터가 없는 라우트에서 /user 페이지 새로고침 테스트 시, Next.js 미들웨어가 페이지 라우팅 레벨에서 먼저 AT 유무를 확인하고, AT가 없으면 API 호출 전에 리다이렉트시킨다. 따라서 apiFetch의 refresh 로직이 실행될 기회가 없었다.
- 백엔드 미들웨어가 API 호출 시점에 토큰을 갱신하므로, 이후 요청에서는 새 쿠키가 설정되어 Next.js 미들웨어도 통과하게 된다.
- 프론트엔드의 refresh 로직이 여전히 필요한 경우:
  - 백엔드 미들웨어가 어떤 이유로 실패했을 때의 fallback  
  - 프론트엔드 미들웨어는 토큰 존재 여부를 판단하고 만료 여부는 판단하지 않고 있음 토큰이 있는데 AT가 만료되었을 경우에는 apiFetch의 refresh 로직이 사용됩니다.  
  - 하지만 쿠키가 만료되면 브라우저에서 삭제되기 때문에 거의 발생하지 않는 안전장치입니다. 그러나 서버와 브라우저의 시간이 다른 경우, 요청 중에 만료된(쿠키 삭제 직전에 요청 -> 서버 도착 시에 JWT 만료), 네트워크 지연 등의 엣지 케이스를 고려해봤씁니다. 거의 발생하지는 않겠지만 혹시 모를 엣지 케이스를 커버할 수도 있으니 일단 남겨뒀습니다.  

## 🧪 테스트 방법

> 리뷰어가 해당 과정만 보고 테스트가 가능하도록 자세히 작성해주세요.  

1. 로그인 후 개발자 도구(Application → Cookies)에서 accessToken과 username 쿠키 삭제  
2. 퀴즈 페이지에서 문제 풀기 시도  
3. 기대 결과: 게스트로 전환되지 않고 로그인 상태 유지, 새 accessToken과 username 쿠키 생성 확인  


## ⚠️ 리뷰 시 참고 사항

## 👀 결과 화면

> 스크린샷 (필요시)

## 📝 관련 이슈

> (예시) closes #12
- closes #235 