### PR TITLE
[feat] 퀴즈 목록 조회 페이징 처리 및 무한 스크롤 반영

### DIFF
--- a/backend/src/common/dto/pagination-response.dto.ts
+++ b/backend/src/common/dto/pagination-response.dto.ts
@@ -1,0 +1,16 @@
+import { Type } from 'class-transformer';
+import { IsInt, Min, Max, IsOptional } from 'class-validator';
+
+export class CursorPaginationDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  cursor?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit: number = 15;
+}

--- a/backend/src/common/dto/pagination.dto.ts
+++ b/backend/src/common/dto/pagination.dto.ts
@@ -1,0 +1,17 @@
+import { Type } from 'class-transformer';
+import { IsInt, Min, Max, IsOptional } from 'class-validator';
+
+export class PaginationDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit: number = 10;
+}

--- a/backend/src/common/interfaces/pagination.interface.ts
+++ b/backend/src/common/interfaces/pagination.interface.ts
@@ -1,0 +1,13 @@
+export interface PaginationOptions {
+  page: number;
+  limit: number;
+}
+
+export interface CursorPaginatedResult<T> {
+  data: T[];
+  meta: {
+    nextCursor: string | null;
+    hasNextPage: boolean;
+    limit: number;
+  };
+}

--- a/backend/src/common/utils/pagination.util.ts
+++ b/backend/src/common/utils/pagination.util.ts
@@ -1,0 +1,20 @@
+import { CursorPaginatedResult } from '../interfaces/pagination.interface';
+
+export function createCursorPaginatedResult<T>(
+  data: T[],
+  limit: number,
+  id: keyof T,
+): CursorPaginatedResult<T> {
+  const hasNextPage = data.length > limit;
+  const items = hasNextPage ? data.slice(0, limit) : data;
+  const nextCursor = hasNextPage ? String(items[items.length - 1][id]) : null;
+
+  return {
+    data: items,
+    meta: {
+      nextCursor,
+      hasNextPage,
+      limit,
+    },
+  };
+}

--- a/backend/src/modules/quizzes/dto/quiz-search.dto.ts
+++ b/backend/src/modules/quizzes/dto/quiz-search.dto.ts
@@ -1,0 +1,12 @@
+import { IsOptional, IsEnum } from 'class-validator';
+import { CursorPaginationDto } from 'src/common/dto/pagination-response.dto';
+import { DifficultyLevel } from 'src/datasources/entities/tb-main-quiz.entity';
+
+export class QuizInfiniteScrollDto extends CursorPaginationDto {
+  @IsOptional()
+  category?: string;
+
+  @IsOptional()
+  @IsEnum(DifficultyLevel)
+  difficulty?: DifficultyLevel;
+}

--- a/backend/src/modules/quizzes/quizzes.controller.ts
+++ b/backend/src/modules/quizzes/quizzes.controller.ts
@@ -7,12 +7,10 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { QuizzesService } from './quizzes.service';
-import {
-  MainQuiz,
-  DifficultyLevel,
-} from '../../datasources/entities/tb-main-quiz.entity';
+import { DifficultyLevel } from '../../datasources/entities/tb-main-quiz.entity';
 import { MultipleChoicesResponseDto } from './dto/quiz-response.dto';
 import { Public } from '../auth/decorator/public.decorator';
+import { QuizInfiniteScrollDto } from './dto/quiz-search.dto';
 
 @Public()
 @Controller('quizzes')
@@ -20,14 +18,8 @@ export class QuizzesController {
   constructor(private readonly quizService: QuizzesService) {}
 
   @Get()
-  async getAllQuizzes(
-    @Query('category') category?: string,
-    @Query('difficulty') difficulty?: DifficultyLevel,
-  ) {
-    const result: MainQuiz[] = await this.quizService.getQuizzes(
-      category,
-      difficulty,
-    );
+  async getAllQuizzes(@Query() searchDto: QuizInfiniteScrollDto) {
+    const result = await this.quizService.getQuizzes(searchDto);
     return result;
   }
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@radix-ui/react-progress": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
+        "@tanstack/react-query": "^5.90.20",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.562.0",
@@ -1670,6 +1671,32 @@
         "@tailwindcss/oxide": "4.1.18",
         "postcss": "^8.4.41",
         "tailwindcss": "4.1.18"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
+      "integrity": "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.20.tgz",
+      "integrity": "sha512-vXBxa+qeyveVO7OA0jX1z+DeyCA4JKnThKv411jd5SORpBKgkcVnYKCiBgECvADvniBX7tobwBmg01qq9JmMJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.20"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@radix-ui/react-progress": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
+    "@tanstack/react-query": "^5.90.20",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.562.0",

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -5,6 +5,7 @@ import ErrorToast from '@/components/ErrorToast';
 import Footer from '@/components/Footer';
 import { Suspense } from 'react';
 import type { Metadata } from 'next';
+import QueryProvider from './providers/QueryProvider';
 
 export const metadata: Metadata = {
   title: 'CS뽁뽁',
@@ -23,12 +24,14 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body className="bg-[var(--color-bg-default)] flex min-h-dvh flex-col">
-        <ConditionalHeader />
-        <Suspense fallback={null}>
-          <ErrorToast />
-        </Suspense>
-        <main className="flex-1">{children}</main>
-        <Footer />
+        <QueryProvider>
+          <ConditionalHeader />
+          <Suspense fallback={null}>
+            <ErrorToast />
+          </Suspense>
+          <main className="flex-1">{children}</main>
+          <Footer />
+        </QueryProvider>
         <ToastContainer />
       </body>
     </html>

--- a/frontend/src/app/providers/QueryProvider.tsx
+++ b/frontend/src/app/providers/QueryProvider.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useState } from 'react';
+
+export default function QueryProvider({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 60 * 1000, // 1분
+            gcTime: 5 * 60 * 1000, // 5분 (구 cacheTime)
+            refetchOnWindowFocus: false,
+            retry: 1,
+          },
+        },
+      }),
+  );
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}

--- a/frontend/src/app/quizzes/components/QuizPageClient.tsx
+++ b/frontend/src/app/quizzes/components/QuizPageClient.tsx
@@ -1,34 +1,154 @@
+'use client';
+
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useEffect, useRef, useMemo } from 'react';
 import DifficultyFilter from './filters/DifficultyFilter';
 import CategoryFilter from './filters/CategoryFilter';
 import QuizGrid from './card/QuizGrid';
 import QuizHeader from './header/QuizHeader';
 import { CategoryCountsResponseDto, Quiz } from '../types/quiz';
+import { fetchQuizzes } from '@/services/apis/quizApi';
 
-interface QuizPageServerProps {
-  quizzes: Quiz[];
-  categories: CategoryCountsResponseDto;
-  category?: string;
-  difficulty?: string;
+interface QuizPageClientProps {
+  initialData: {
+    data: Quiz[];
+    meta: {
+      nextCursor: string | null;
+      hasNextPage: boolean;
+      limit: number;
+    };
+  };
+  filters: {
+    category?: string;
+    difficulty?: string;
+  };
   username: string;
 }
 
-export default function QuizPageServer({
-  quizzes,
-  categories,
-  category,
-  difficulty,
-  username,
-}: QuizPageServerProps) {
+export default function QuizPageClient({ initialData, filters, username }: QuizPageClientProps) {
+  const { category, difficulty } = filters;
+
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useInfiniteQuery({
+    queryKey: ['quizzes', category, difficulty],
+    queryFn: async ({ pageParam }: { pageParam: string | null }) => {
+      const result = await fetchQuizzes({
+        cursor: pageParam ?? undefined,
+        limit: 20,
+        category,
+        difficulty,
+      });
+
+      return {
+        data: result.data,
+        nextCursor: result.meta.nextCursor,
+        hasMore: result.meta.hasNextPage,
+      };
+    },
+    getNextPageParam: (lastPage) => {
+      return lastPage.hasMore ? lastPage.nextCursor : null;
+    },
+    initialPageParam: null,
+  });
+
+  const observerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage();
+        }
+      },
+      { threshold: 0.1 },
+    );
+
+    if (observerRef.current) {
+      observer.observe(observerRef.current);
+    }
+
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  // 모든 페이지의 퀴즈를 하나의 배열로 합치기
+  const allQuizzes = data?.pages.flatMap((page) => page.data) ?? [];
+
+  // ⭐ 현재 조회된 데이터를 기반으로 카테고리 카운트 계산
+  const categoryCounts = useMemo((): CategoryCountsResponseDto => {
+    const categoryMap = new Map<
+      string,
+      {
+        quizCategoryId: number;
+        id: number;
+        name: string;
+        count: number;
+      }
+    >();
+
+    allQuizzes.forEach((quiz) => {
+      const categoryName = quiz.quizCategory.name;
+      const categoryId = quiz.quizCategory.quizCategoryId;
+
+      if (!categoryMap.has(categoryName)) {
+        categoryMap.set(categoryName, {
+          quizCategoryId: categoryId,
+          id: categoryId,
+          name: categoryName,
+          count: 0,
+        });
+      }
+
+      const category = categoryMap.get(categoryName)!;
+      category.count += 1;
+    });
+
+    return {
+      totalCount: allQuizzes.length,
+      categories: Array.from(categoryMap.values()),
+    };
+  }, [allQuizzes]);
+
   return (
-    <main className="mx-auto p-10 bg-[var(--color-bg-default)]">
-      <QuizHeader username={username} />
+    <div className="flex justify-center min-h-screen w-full">
+      <div className="w-3/4 min-w-full">
+        <div className="mx-auto min-w-100 max-w-350 p-10 bg-[var(--color-bg-default)]">
+          <QuizHeader username={username} />
 
-      <div className="flex justify-between items-center">
-        <DifficultyFilter difficulty={difficulty} category={category} />
-        <CategoryFilter categoriesData={categories} category={category} difficulty={difficulty} />
+          <div className="flex justify-between items-center mb-6">
+            <DifficultyFilter difficulty={difficulty} category={category} />
+            <CategoryFilter
+              categoriesData={categoryCounts}
+              category={category}
+              difficulty={difficulty}
+            />
+          </div>
+
+          {isLoading ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-10">
+              {[...Array(6)].map((_, i) => (
+                <div key={i} className="h-64 bg-gray-200 animate-pulse rounded-lg" />
+              ))}
+            </div>
+          ) : (
+            <>
+              <QuizGrid quizzes={allQuizzes} />
+
+              {allQuizzes.length > 0 && <div ref={observerRef} className="h-10 w-full" />}
+
+              {isFetchingNextPage && (
+                <div className="text-center py-8">
+                  <p className="text-gray-500">퀴즈를 더 불러오는 중...</p>
+                </div>
+              )}
+
+              {!hasNextPage && allQuizzes.length > 0 && (
+                <div className="text-center py-8">
+                  <p className="text-gray-500">모든 퀴즈를 불러왔습니다.</p>
+                </div>
+              )}
+            </>
+          )}
+        </div>
       </div>
-
-      <QuizGrid quizzes={quizzes} />
-    </main>
+    </div>
   );
 }

--- a/frontend/src/app/quizzes/components/card/QuizGrid.tsx
+++ b/frontend/src/app/quizzes/components/card/QuizGrid.tsx
@@ -2,15 +2,29 @@ import { Quiz } from '../../types/quiz';
 import QuizCard from './QuizCard';
 import { MESSAGES } from '@/constants/quizzes.constant';
 
-interface Quizzes {
+interface QuizGridProps {
   quizzes: Quiz[];
+  isLoading?: boolean;
 }
 
-export default function QuizGrid({ quizzes }: Quizzes) {
+export default function QuizGrid({ quizzes, isLoading }: QuizGridProps) {
+  // 초기 로딩 중
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-10">
+        {[...Array(6)].map((_, i) => (
+          <div key={i} className="h-64 bg-gray-200 animate-pulse rounded-lg" />
+        ))}
+      </div>
+    );
+  }
+
+  // 퀴즈 없음
   if (quizzes.length === 0) {
     return <p className="col-span-full text-center text-gray-500 py-10">{MESSAGES.NO_QUIZZES}</p>;
   }
 
+  // 퀴즈 표시
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-10">
       {quizzes.map((quiz) => (

--- a/frontend/src/app/quizzes/page.tsx
+++ b/frontend/src/app/quizzes/page.tsx
@@ -1,8 +1,9 @@
 import { Suspense } from 'react';
 import QuizPageServer from './components/QuizPageServer';
-import { fetchAllQuizzes } from '@/services/apis/quizApi';
+import { fetchAllQuizzes, fetchQuizzes } from '@/services/apis/quizApi';
 import { filterQuizzesByParams, calculateCategoryCounts } from './utils/serverFilters';
 import { cookies } from 'next/headers';
+import QuizPageClient from './components/QuizPageClient';
 
 interface PageProps {
   searchParams: Promise<{
@@ -24,19 +25,20 @@ export default async function Page({ searchParams }: PageProps) {
   const allQuizzes = await fetchAllQuizzes();
 
   // 2. 서버에서 필터링
-  const filteredQuizzes = filterQuizzesByParams(allQuizzes, category, difficulty);
+  const filteredQuizzes = filterQuizzesByParams(allQuizzes.data, category, difficulty);
 
   // 3. 서버에서 카테고리 카운트 계산
-  const categoryCounts = calculateCategoryCounts(allQuizzes, difficulty);
+  const categoryCounts = calculateCategoryCounts(allQuizzes.data, difficulty);
+
+  // 초기 데이터만 로드 (첫 페이지)
+  const initialData = await fetchQuizzes({});
 
   return (
     <>
       <Suspense fallback={null}>
-        <QuizPageServer
-          quizzes={filteredQuizzes}
-          categories={categoryCounts}
-          category={category}
-          difficulty={difficulty}
+        <QuizPageClient
+          initialData={initialData}
+          filters={{ category, difficulty }}
           username={username}
         />
       </Suspense>

--- a/frontend/src/app/quizzes/types/quiz.ts
+++ b/frontend/src/app/quizzes/types/quiz.ts
@@ -20,6 +20,19 @@ export interface Quiz {
   quizCategory: QuizCategory;
 }
 
+// 페이지네이션 메타데이터
+export interface PaginationMeta {
+  nextCursor: string | null;
+  hasNextPage: boolean;
+  limit: number;
+}
+
+// 퀴즈 목록 응답 데이터
+export interface QuizListData {
+  data: Quiz[];
+  meta: PaginationMeta;
+}
+
 export interface QuizCategoryWithCount extends QuizCategory {
   id: number;
   name: string;

--- a/frontend/src/services/apis/quizApi.ts
+++ b/frontend/src/services/apis/quizApi.ts
@@ -1,13 +1,25 @@
 import { QuizChecklistResponseDto } from '@/app/checklist/types/checklist.types';
-import { Quiz, CategoryCountsResponseDto, DIFFICULTY_MAP } from '@/app/quizzes/types/quiz';
+import {
+  Quiz,
+  CategoryCountsResponseDto,
+  DIFFICULTY_MAP,
+  QuizListData,
+} from '@/app/quizzes/types/quiz';
 import { apiFetch } from '@/services/http/apiFetch';
 
 export interface ChecklistSubmitResponseDto {
   savedCount: number;
 }
 
-export async function fetchAllQuizzes(): Promise<Quiz[]> {
-  const data = await apiFetch<Quiz[]>(
+interface FetchQuizzesParams {
+  cursor?: string | null;
+  limit?: number;
+  category?: string;
+  difficulty?: string;
+}
+
+export async function fetchAllQuizzes(): Promise<QuizListData> {
+  const data = await apiFetch<QuizListData>(
     '/quizzes',
     { method: 'GET', next: { revalidate: 3600 } },
     { message: '퀴즈 목록 응답 데이터가 없습니다.' },
@@ -16,9 +28,17 @@ export async function fetchAllQuizzes(): Promise<Quiz[]> {
   return data;
 }
 
-export async function fetchQuizzes(category?: string, difficulty?: string): Promise<Quiz[]> {
-  const params = new URLSearchParams();
+export async function fetchQuizzes({
+  cursor,
+  limit = 20,
+  category,
+  difficulty,
+}: FetchQuizzesParams): Promise<QuizListData> {
+  const params = new URLSearchParams({
+    limit: limit.toString(),
+  });
 
+  if (cursor) params.append('cursor', cursor);
   if (category) params.append('category', category);
   if (!!difficulty && difficulty in DIFFICULTY_MAP) {
     params.append('difficulty', difficulty);
@@ -26,7 +46,7 @@ export async function fetchQuizzes(category?: string, difficulty?: string): Prom
 
   const query = params.toString();
 
-  const data = await apiFetch<Quiz[]>(
+  const data = await apiFetch<QuizListData>(
     `/quizzes${query ? `?${query}` : ''}`,
     { method: 'GET', cache: 'no-store' },
     { message: '퀴즈 목록 응답 데이터가 없습니다.' },


### PR DESCRIPTION
## 📌 작업 내용

> 무엇을 구현/수정했는지 간단 요약

- 퀴즈 목록 조회 페이징 처리 및 무한 스크롤 구현

## 🔍 주요 변경 사항

## 1. BE) 퀴즈 목록 조회 API 페이징 추가

### 수정된 API
* **API**: `GET /quizzes`
* 기존 전체 조회 방식에서 **커서 기반 페이징**으로 변경
* 기본 **15개씩** 조회 (limit 파라미터로 조정 가능)
* 무한 스크롤 구현을 위한 커서 방식 채택

### 동작 방식
* 현재 페이지의 마지막 ID를 다음 요청의 커서로 사용
* 커서 ID보다 큰 값부터 조회하여 연속된 데이터 로드

### 공통 페이징 처리 로직 분리
* 재사용 가능하도록 페이징 로직을 공통 모듈로 분리
* 향후 다른 목록 조회 API에도 적용 가능

---

## 2. FE) 무한 스크롤 구현

### TanStack Query (React Query) 도입
* 커서 기반 무한 스크롤 구현을 위해 **TanStack Query** 도입
* 페이징 상태(마지막 ID, 다음 페이지 존재 여부 등)를 효율적으로 관리
* `useState`보다 캐싱, 자동 리페칭 등의 장점 제공

### 커서 방식 vs Offset 방식

#### Offset 방식의 문제점

**1. 성능 저하**
```sql
-- 1페이지 (0~10)
SELECT * FROM posts ORDER BY id LIMIT 10 OFFSET 0;  -- 10개 스캔

-- 100페이지 (990~1000)
SELECT * FROM posts ORDER BY id LIMIT 10 OFFSET 990;  -- 1000개 스캔

-- 10000페이지
SELECT * FROM posts ORDER BY id LIMIT 10 OFFSET 99990;  -- 100,000개 스캔
```

* 페이지가 깊어질수록 성능 급격히 저하
* DB가 OFFSET만큼의 데이터를 읽고 버리는 비효율 발생

**2. 사용자 경험 측면**
* 전통적인 페이지 번호 방식 (1, 2, 3...)
* 사용자가 주로 앞쪽 페이지만 확인하는 경향

#### 커서 방식의 장점

```sql
-- 커서 기반 (마지막 본 ID 이후부터)
SELECT * FROM posts WHERE id > 100 ORDER BY id LIMIT 10;  -- 항상 일정한 성능
```

* **인덱스 활용**: 원하는 위치로 직접 점프
* **일정한 성능**: 페이지 깊이와 무관하게 동일한 성능
* **더 나은 UX**: 끊김 없는 스크롤 경험 제공

### 아키텍처 변경
* 기존: **서버 컴포넌트**로 SSR 방식 조회
* 변경: **클라이언트 컴포넌트**로 전환하여 React Query 적용

### useInfiniteQuery 사용

**useInfiniteQuery**는 무한 스크롤에 최적화된 React Query 훅입니다.

#### 전체 동작 흐름

```javascript
1. 컴포넌트 마운트
   → queryFn 실행 (pageParam = undefined)
   → fetchQuizzes({ cursor: undefined, limit: 20, ... })
   → 첫 20개 퀴즈 로드

2. 사용자 스크롤 → fetchNextPage() 호출
   → getNextPageParam으로 nextCursor 계산
   → queryFn 실행 (pageParam = "cursor_value_1")
   → fetchQuizzes({ cursor: "cursor_value_1", limit: 20, ... })
   → 다음 20개 퀴즈 추가

3. 추가 스크롤 → fetchNextPage()
   → queryFn 실행 (pageParam = "cursor_value_2")
   → 또 다음 20개 추가

4. 마지막 페이지 도달
   → hasMore = false
   → getNextPageParam이 undefined 반환
   → hasNextPage = false (더보기 버튼/로딩 비활성화)
```

## 🧪 테스트 방법

> 리뷰어가 해당 과정만 보고 테스트가 가능하도록 자세히 작성해주세요.

- 서버 실행
- 퀴즈 목록 페이지 접속 후, 확인 !
- 데이터를 20개 이상 넣어야 무한스크롤 확인이 가능합니다 !

## ⚠️ 리뷰 시 참고 사항
- 현재 클라이언트 컴포넌트로 변경 및 페이징 처리를 진행하면서 카테고리쪽 필터링이 UX적으로 부자연스러운 부분들이 보여 디자인 수정 또는 다른 방안을 찾아보아야할 것 같습니다.(기능상 문제는 없는 것을 확인했습니다)
  - 페이징 처리로 인해 초기 로드 시 첫 20개 퀴즈에 해당하는 카테고리만 필터에 표시됩니다.
  - 사용자가 스크롤하여 추가 데이터를 조회하면 새로운 카테고리가 필터에 동적으로 추가되면서 부자연스러운 UX가 발생합니다.

- 개선 방향 (검토 필요)
  - 전체 카테고리 목록을 사전 로드하여 필터 옵션 고정
  > 인프런 참고 - 이런식으로 고정하는 것도 좋을 것 같아요 !
<img width="1406" height="112" alt="image" src="https://github.com/user-attachments/assets/09721097-1134-42fa-a282-78e0ba315342" />

  - 또는 카테고리 필터 UI/UX 개선 필요
## 👀 결과 화면

> 스크린샷 (필요시)


https://github.com/user-attachments/assets/1e66088f-7186-4a4f-8c25-f65305c46850



## 📝 관련 이슈

> (예시) closes #<이슈번호>

closes #236 
