### PR TITLE
[fix] 나의 답변 textarea 크기 고정 및 스크롤 기능 추가

### DIFF
--- a/frontend/src/app/checklist/components/ChecklistSection.tsx
+++ b/frontend/src/app/checklist/components/ChecklistSection.tsx
@@ -110,7 +110,7 @@ export default function ChecklistSection({
   };
 
   return (
-    <div className="px-12 py-12 md:px-16 md:py-16 lg:px-24 lg:py-24 xl:px-32">
+    <div className="px-12 py-4 md:px-16 md:py-8 lg:px-24 lg:py-10 xl:px-32">
       {isAnalyzing && (
         <Loader
           message="CS 뽁뽁 생성 중..."

--- a/frontend/src/app/checklist/components/MySpeechText.tsx
+++ b/frontend/src/app/checklist/components/MySpeechText.tsx
@@ -12,12 +12,6 @@ interface MySpeechTextProps {
 export default function MySpeechText({ speechItem, setSpeechItem }: MySpeechTextProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  useEffect(() => {
-    if (textareaRef.current) {
-      textareaRef.current.style.height = 'auto';
-      textareaRef.current.style.height = textareaRef.current.scrollHeight + 'px';
-    }
-  }, [speechItem.speechText]);
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const speechTextValue = e.target.value;
 
@@ -42,8 +36,8 @@ export default function MySpeechText({ speechItem, setSpeechItem }: MySpeechText
           ref={textareaRef}
           value={speechItem.speechText}
           onChange={handleChange}
-          className="rounded-xl p-6 border-2 mb-6 w-full min-h-[700px] resize-none text-gray-800 text-lg leading-relaxed focus:outline-none focus:ring-2 focus:ring-blue-400"
-          style={{ backgroundColor: '#4278FF10', borderColor: '#4278FF', overflow: 'hidden' }}
+          className="rounded-xl p-6 border-2 mb-6 w-full h-[700px] resize-none text-gray-800 text-lg leading-relaxed focus:outline-none focus:ring-2 focus:ring-blue-400 overflow-y-auto"
+          style={{ backgroundColor: '#4278FF10', borderColor: '#4278FF' }}
         />
       </div>
       <div className="flex justify-end text-sm text-gray-500">


### PR DESCRIPTION
## 📌 작업 내용

> 무엇을 구현/수정했는지 간단 요약

- 나의 답변 textarea 크기 고정 및 스크롤 기능 추가 

## 🔍 주요 변경 사항
### 기존 셀프체크와 문제 사이 간격 조절
- 셀프체크 컴포넌트와 문제 사이의 간격이 너무 넓은 것 같아 높이를 조절해주었습니다.

### 나의 답변 textarea 크기 고정 및 스크롤 기능 추가
- useEffect로 자동 높이 조절 설정이 되어 있어 해당 로직을 제거했습니다.(크기 고정을 위함)
  - min-h-[700px] → h-[700px]로 변경하여 고정 높이 설정
- overflow-y-auto 클래스를 추가하여 세로 스크롤이 반영되도록 했습니다.

## 🧪 테스트 방법

> 리뷰어가 해당 과정만 보고 테스트가 가능하도록 자세히 작성해주세요.

- 나의 답변에 글자를 1000자 이상 입력하여 스크롤바가 생기는지 확인

## ⚠️ 리뷰 시 참고 사항

## 👀 결과 화면

> 스크린샷 (필요시)

https://github.com/user-attachments/assets/584053f0-73fb-47bf-8145-f49f7032aff3


## 📝 관련 이슈

> (예시) closes #<이슈번호>

closes #245 