### PR TITLE
[fix] 말하기 답변 페이지, 체크리스트 페이지 ui 수정  

### DIFF
--- a/frontend/src/app/checklist/components/Checklist.tsx
+++ b/frontend/src/app/checklist/components/Checklist.tsx
@@ -14,15 +14,15 @@ export const Checklist: React.FC<ChecklistProps> = ({
     <div className="w-full max-w-2xl mx-auto bg-white p-5">
       <h1 className="text-2xl font-bold text-center mb-8">📝 체크리스트</h1>
 
-      <div className="mb-6">
-        <h2 className="text-xl font-medium mb-2">{username}님,</h2>
-        <h2 className="text-xl font-medium mb-2">얼마나 답변했다고 생각하시나요?</h2>
+      <div className="mb-3">
+        <h2 className="text-xl font-medium">{username}님,</h2>
+        <h2 className="text-xl font-medium">얼마나 답변했다고 생각하시나요?</h2>
         <p className="text-base text-gray-500">
           어디서 막혔었는지 뒤돌아보신다면 성장에 도움이 되실거에요.
         </p>
       </div>
 
-      <div className="grid grid-cols-3 gap-4 mb-6">
+      <div className="grid grid-cols-3 gap-4 mb-3">
         <FeelingButton
           comprehensionLevel="LOW"
           label="답변을 못했어요"

--- a/frontend/src/app/checklist/components/MySpeechText.tsx
+++ b/frontend/src/app/checklist/components/MySpeechText.tsx
@@ -31,13 +31,13 @@ export default function MySpeechText({ speechItem, setSpeechItem }: MySpeechText
       <p className="text-base mb-4 text-gray-500">
         다시 읽어보며 필요한 부분은 자유롭게 수정할 수 있어요 ✨
       </p>
-      <div className="mb-6">
+      <div>
         <textarea
           ref={textareaRef}
           value={speechItem.speechText}
           onChange={handleChange}
-          className="rounded-xl p-6 border-2 mb-6 w-full h-[700px] resize-none text-gray-800 text-lg leading-relaxed focus:outline-none focus:ring-2 focus:ring-blue-400 overflow-y-auto"
-          style={{ backgroundColor: '#4278FF10', borderColor: '#4278FF' }}
+          className="rounded-xl p-6 border-2 mb-3 w-full resize-none text-gray-800 text-lg leading-relaxed focus:outline-none focus:ring-2 focus:ring-blue-400 overflow-y-auto"
+          style={{ height: 600, backgroundColor: '#4278FF10', borderColor: '#4278FF' }}
         />
       </div>
       <div className="flex justify-end text-sm text-gray-500">

--- a/frontend/src/app/checklist/main-quiz/[main-quiz-id]/page.tsx
+++ b/frontend/src/app/checklist/main-quiz/[main-quiz-id]/page.tsx
@@ -41,14 +41,19 @@ export default async function ResultPage({
 
   return (
     <main>
-      <div className="flex justify-center pt-10">
+      <div className="flex justify-center pt-10 pb-4">
         <QuizInfoBadge
           quizCategoryName={quiz.quizCategory.name}
           difficultyLevel={quiz.difficultyLevel}
         />
       </div>
-      <div className="flex justify-center pt-10">
-        <h1 className="flex justify-center text-2xl font-semibold">{quiz.content}</h1>
+      <div className="flex justify-center px-10">
+        <h1
+          className="max-w-[900px] text-2xl font-semibold text-center leading-relaxed break-keep tracking-tight"
+          style={{ wordBreak: 'keep-all' }} // 단어가 잘리지 않게 설정
+        >
+          {quiz.content}
+        </h1>
       </div>
       {/* 상호작용 필요한 부분 - 클라이언트 컴포넌트 */}
       <ChecklistSection

--- a/frontend/src/app/main-quiz/[id]/components/Recorder.tsx
+++ b/frontend/src/app/main-quiz/[id]/components/Recorder.tsx
@@ -350,7 +350,7 @@ export default function Recorder({ quizId, onSwitchToTextMode }: AudioRecorderPr
   const isSubmitting = recordStatus === 'submitting';
 
   return (
-    <div>
+    <div className="w-full">
       {/* 제출 중 로딩 모달 */}
       {isSubmitting && (
         <Loader
@@ -367,7 +367,7 @@ export default function Recorder({ quizId, onSwitchToTextMode }: AudioRecorderPr
       />
 
       {/* 메인 컨텐츠: 좌우 레이아웃 */}
-      <div className="px-12 py-4 max-w-350">
+      <div className="px-12 py-4 max-w-250 mx-auto">
         <div className="grid grid-cols-1 lg:grid-cols-5 gap-6">
           {/* 비디오 */}
           <div className="space-y-6 lg:col-span-3">

--- a/frontend/src/app/main-quiz/[id]/page.tsx
+++ b/frontend/src/app/main-quiz/[id]/page.tsx
@@ -13,7 +13,7 @@ export default async function MainQuizPage({ params }: PageProps) {
 
   return (
     <main className="pb-10">
-      <div className="flex justify-center pt-5 pb-4">
+      <div className="flex justify-center pt-10 pb-4">
         <QuizInfoBadge
           size="sm"
           quizCategoryName={quiz.quizCategory.name}


### PR DESCRIPTION
## 📌 작업 내용

> 무엇을 구현/수정했는지 간단 요약

- 메인퀴즈 말하기 답변 페이지와 체크리스트 페이지의 레이아웃 안정성 및 여백을 개선합니다.
  - 말하기 답변 페이지에서 권한 동의 전후로 미러링 화면과 장치 선택 컴포넌트 사이 간격이 변동되는 문제 해결
  - 체크리스트 페이지에서 quiz.content가 길 때 레이아웃이 깨지는 문제 해결
  - 체크리스트 페이지 불필요한 여백 축소로 스크롤 감소 

## 🔍 주요 변경 사항
### 1. 마이크/카메라 동의 후 미러링 화면과 장치 선택 간격이 변동되는 문제 해결
- 문제  
  - 권한 동의 모달을 닫은 후, 미러링 화면과 장치 선택 컴포넌트 사이의 간격이 동의 전 배경에서 보이던 것과 달라지는 현상이 발생했습니다.  
- 해결 
  - AnswerModeSection이 Recorder를 flex justify-center로 감싸고 있어, Recorder의 바깥 `<div>`가 flex item으로서 콘텐츠 기반으로 너비가 결정되는 구조였습니다. w-full을 추가하여 항상 부모 전체 너비를 차지하도록 고정하고, mx-auto로 센터링을 유지함으로써 동의 전후 내부 상태 변화와 무관하게 그리드 컨테이너 너비가 일정하게 유지되도록 했습니다.  

파일 | 변경 | 이유
-- | -- | --
Recorder.tsx | 바깥 `<div>`에 w-full 추가 | flex item이 콘텐츠에 따라 줄어들지 않고, 항상 부모 전체 너비를 차지하도록 고정
Recorder.tsx | grid wrapper에 mx-auto 추가 | w-full로 인해 flex justify-center 센터링이 무효화되므로 mx-auto로 가운데 정렬 유지
Recorder.tsx  | max-w-350 → max-w-250 | 비디오와 장치 선택 컴포넌트 사이 여유 공간 축소

### 2. 체크리스트 페이지 quiz.content 레이아웃 개선

- 문제: 메인퀴즈 페이지에서는 quiz.content에 max-w, px, break-keep 등이 적용되어 긴 텍스트도 2줄로 자연스럽게 표시되지만, 체크리스트 페이지에는 미적용 상태였습니다.

- 해결: 체크리스트 페이지 page.tsx에 동일한 스타일 적용 (max-w-[900px], break-keep, leading-relaxed, px-10)

### 3. 체크리스트 페이지 여백 축소
스크롤을 최소화하기 위해 불필요한 여백을 축소  
파일 | 변경
-- | --
MySpeechText.tsx | textarea h-[700px] (Tailwind class) → height: 600 (inline style)으로 변경. Tailwind arbitrary value의 JIT 컴파일 의존성 제거
MySpeechText.tsx | textarea 하단 mb-6 → mb-3, wrapper mb-6 제거
Checklist.tsx | 질문 영역 mb-6 → mb-3, 제목 mb-2 제거, 감정 버튼 영역 mb-6 → mb-3


## 🧪 테스트 방법

> 리뷰어가 해당 과정만 보고 테스트가 가능하도록 자세히 작성해주세요.

## ⚠️ 리뷰 시 참고 사항

- MySpeechText의 textarea 높이를 Tailwind class(h-[700px])에서 inline style(height: 600)로 변경한 이유  
  - h-[600px]로 변경했을 때 textarea의 높이가 굉장히 축소되어서 보였는데 700보다 큰 숫자를 해도 똑같이 보였습니다. 
  - Tailwind JIT가 arbitrary value 변경 시 새 클래스를 즉시 컴파일하지 못하는 경우가 있어, 높이 조정이 반영되지 않는 문제가 있고 px 크기를 조정해도 반영되어서 보이지 않는 이유일 것이라고 예상했습니다. inline style은 Tailwind 빌드 파이프라인과 무관하게 항상 적용되기 때문에 변경했습니다. 

## 👀 결과 화면
> 스크린샷 (필요시)  

### 말하기 답변 비디오 컴포넌트와 장치 선택 컴포넌트 간격 부자연스러운 점 해결하기 전  
https://github.com/user-attachments/assets/fe0a0004-216d-4e1b-8c43-9d557c696955  

### 말하기 답변 비디오 컴포넌트와 장치 선택 컴포넌트 간격 부자연스러운 점 해결한 후

https://github.com/user-attachments/assets/19a5f398-a502-4847-a25b-b23ee2b6d2f4

### 체크리스트 페이지 quiz.content 내용 길 때 수정하기 전
<img width="900" alt="image" src="https://github.com/user-attachments/assets/3b29e4cc-88e7-4d83-aea0-04b75715629f" />


### 체크리스트 페이지 간격 조정 전  
https://github.com/user-attachments/assets/9e07abc5-2963-4b03-9d46-347ba5732274

### 체크리스트 페이지 간격 조정 후 
https://github.com/user-attachments/assets/0c68b908-16c7-418c-8de4-d23fe53da9f0




## 📝 관련 이슈

> (예시) closes #12

- closes #243

