### PR TITLE
[feat] 퀴즈 목록 최상단으로 올라가기 버튼 구현

### DIFF
--- a/frontend/src/app/quizzes/components/BackToTopButton.tsx
+++ b/frontend/src/app/quizzes/components/BackToTopButton.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { Fragment, useEffect, useState } from 'react';
+
+export default function BackToTopButton() {
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 200) {
+        setShow(true);
+      } else {
+        setShow(false);
+      }
+    });
+  });
+
+  const jumpToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth', // 애니메이션 효과
+    });
+  };
+
+  return (
+    <Fragment>
+      {show ? (
+        <div className="fixed bottom-0 right-0 mb-6 mr-6 z-10">
+          <button
+            onClick={jumpToTop}
+            className="bg-black text-white rounded-full p-2 hover:bg-gray-900 transition cursor-pointer"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke-width="1.5"
+              stroke="currentColor"
+              className="size-6"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 15.75 7.5-7.5 7.5 7.5" />
+            </svg>
+          </button>
+        </div>
+      ) : (
+        <Fragment />
+      )}
+    </Fragment>
+  );
+}

--- a/frontend/src/app/quizzes/components/BackToTopButton.tsx
+++ b/frontend/src/app/quizzes/components/BackToTopButton.tsx
@@ -34,11 +34,11 @@ export default function BackToTopButton() {
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
               viewBox="0 0 24 24"
-              stroke-width="1.5"
+              strokeWidth="1.5"
               stroke="currentColor"
               className="size-6"
             >
-              <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 15.75 7.5-7.5 7.5 7.5" />
+              <path strokeLinecap="round" strokeLinejoin="round" d="m4.5 15.75 7.5-7.5 7.5 7.5" />
             </svg>
           </button>
         </div>

--- a/frontend/src/app/quizzes/components/BackToTopButton.tsx
+++ b/frontend/src/app/quizzes/components/BackToTopButton.tsx
@@ -28,7 +28,7 @@ export default function BackToTopButton() {
         <div className="fixed bottom-0 right-0 mb-6 mr-6 z-10">
           <button
             onClick={jumpToTop}
-            className="bg-black text-white rounded-full p-2 hover:bg-gray-900 transition cursor-pointer"
+            className="bg-[var(--color-primary)] text-white rounded-full p-2 cursor-pointer"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/app/quizzes/page.tsx
+++ b/frontend/src/app/quizzes/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from 'react';
 import { fetchAllQuizzes, fetchQuizzes } from '@/services/apis/quizApi';
 import { cookies } from 'next/headers';
 import QuizPageClient from './components/QuizPageClient';
+import BackToTopButton from './components/BackToTopButton';
 
 interface PageProps {
   searchParams: Promise<{
@@ -31,6 +32,7 @@ export default async function Page({ searchParams }: PageProps) {
           username={username}
         />
       </Suspense>
+      <BackToTopButton />
     </>
   );
 }


### PR DESCRIPTION
## 📌 작업 내용

> 무엇을 구현/수정했는지 간단 요약

무한스크롤 진행 시, 최상단으로 올라가기 버튼 추가

## 🔍 주요 변경 사항
### BackToTopButton.tsx 컴포넌트 추가
- 상단으로 올라가기 버튼을 구현하기 위해 컴포넌트를 분리하여 구현했습니다.
- 현재, 퀴즈 리스트에서만 활용될 것으로 판단되어 quizzes 폴더 내부 컴포넌트에 구성했습니다.
- 구현 방식은 다음과 같습니다.
```
- window.scrollTo() 사용해서 스크롤 위치 이동
- useState로 버튼 표시/숨김 상태 관리
- useEffect에서 스크롤 이벤트 리스너 등록
```

## 🧪 테스트 방법

> 리뷰어가 해당 과정만 보고 테스트가 가능하도록 자세히 작성해주세요.

- 퀴즈 목록 페이지에 접속합니다.
- 스크롤을 하여 퀴즈 목록을 조회합니다.
- 오른쪽 하단에 상단으로 올라가기 버튼이 생성되는지 확인합니다.
- 버튼 클릭 시, 최상단으로 이동합니다.

## ⚠️ 리뷰 시 참고 사항

- 무신사 UI를 참고하여 디자인 반영했습니다.
- [back to top button nextjs](https://gist.github.com/robert-kratz/e750685a279c8701beafdcb2800bdd2c)

## 👀 결과 화면

> 스크린샷 (필요시)

<img width="1439" height="808" alt="image" src="https://github.com/user-attachments/assets/c2c223f3-e158-460e-9cbc-57aa0200031d" />

> 동작 관련 영상(현재는 포인트 컬러로 변경했습니다 !)

https://github.com/user-attachments/assets/8943d9df-ba81-4a90-a72e-d6531cd95163


## 📝 관련 이슈

> (예시) closes #<이슈번호>

closes #257 
