### PR TITLE
[feat] 헤더 영역 코멘트 말풍선 추가

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.1",
+  "version": "3.0.2",
   "description": "",
   "author": "",
   "private": true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.1.0",
+  "version": "3.0.2",
   "private": true,
   "scripts": {
     "dev": "next dev -H 0.0.0.0",

--- a/frontend/src/app/checklist/components/ChecklistSection.tsx
+++ b/frontend/src/app/checklist/components/ChecklistSection.tsx
@@ -156,7 +156,7 @@ export default function ChecklistSection({
         </Button>
 
         <Button variant="primary" size="fixed" onClick={handleSubmit}>
-          다음
+          피드백 받기
         </Button>
       </div>
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -207,6 +207,27 @@
   }
 }
 
+
 .animate-wave-dance {
   animation: wave-dance 1s ease-in-out infinite;
+}
+
+
+@keyframes float-glow {
+  0% {
+    transform: translateY(3px);  /* 시작: 아래 */
+    filter: brightness(1);
+  }
+  50% {
+    transform: translateY(-3px);  /* 중간: 위 */
+    filter: brightness(1.2);
+  }
+  100% {
+    transform: translateY(3px);  /* 끝: 아래 */
+    filter: brightness(1);
+  }
+}
+
+.animate-float-glow {
+  animation: float-glow 2.5s ease-in-out infinite;
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -354,7 +354,7 @@ export default function Home() {
             <h2 className="text-2xl md:text-4xl font-bold text-gray-900 mb-6 leading-tight">
               설명할 수 없다면,
               <br className="md:hidden" />
-              <span className="text-[var(--color-primary)]">아는 것이 아닙니다.</span>
+              <span className="text-[var(--color-primary)]"> 아는 것이 아닙니다.</span>
             </h2>
 
             <p className="text-gray-500 text-lg mb-10">

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, Fragment } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
@@ -89,27 +89,27 @@ export default function Header() {
                 w-10 h-10 rounded-full overflow-hidden cursor-pointer
                 ${isDropdownOpen ? 'ring-2 ring-[var(--color-primary)] ring-offset-2 scale-105 shadow-md border-transparent' : ''}
               `}
-            >
-              <Image
-                src="/images/header-profile.svg"
-                alt="내 프로필"
-                width={40}
-                height={40}
-                className="object-cover"
-              />
-            </button>
-            {isDropdownOpen && (
-              <div className="absolute right-0 mt-5 w-60 bg-white rounded-xl shadow-xl border border-[var(--color-gray-light)] overflow-hidden animate-in fade-in zoom-in-95 duration-200 origin-top-right">
-                <div className="p-1">
-                  <Link
-                    href="/user"
-                    onClick={() => setIsDropdownOpen(false)}
-                    className="w-full flex items-center gap-3 px-3 py-2.5 text-sm text-[var(--color-gray-dark)] rounded-lg hover:bg-blue-50 hover:text-[var(--color-primary)] transition-colors"
-                    draggable={false}
-                    onDragStart={(e) => e.preventDefault()}
-                  >
-                    📄 리포트
-                  </Link>
+              >
+                <Image
+                  src="/images/default-profile.svg"
+                  alt="내 프로필"
+                  width={40}
+                  height={40}
+                  className="object-cover"
+                />
+              </button>
+              {isDropdownOpen && (
+                <div className="absolute right-0 mt-5 w-60 bg-white rounded-xl shadow-xl border border-[var(--color-gray-light)] overflow-hidden animate-in fade-in zoom-in-95 duration-200 origin-top-right">
+                  <div className="p-1">
+                    <Link
+                      href="/user"
+                      onClick={() => setIsDropdownOpen(false)}
+                      className="w-full flex items-center gap-3 px-3 py-2.5 text-sm text-[var(--color-gray-dark)] rounded-lg hover:bg-blue-50 hover:text-[var(--color-primary)] transition-colors"
+                      draggable={false}
+                      onDragStart={(e) => e.preventDefault()}
+                    >
+                      📄 리포트
+                    </Link>
 
                     <button
                       onClick={handleLogoutClick}
@@ -124,21 +124,31 @@ export default function Header() {
               )}
             </div>
           ) : (
-            <button
-              onClick={handleNaverLogin}
-              className={`
-              ${commonButtonClass}
-              px-6 py-2 rounded-full 
-              border border-[var(--color-primary)]
-              text-[var(--color-primary)] text-sm font-bold cursor-pointer
-                          variant="secondary"
-            size="cta"
-            `}
-              draggable={false}
-              onDragStart={(e) => e.preventDefault()}
-            >
-              로그인
-            </button>
+            <div className="relative">
+              <div className="absolute right-full mr-3 top-1/2 -translate-y-1/2 animate-float-glow">
+                <div className="bg-[var(--color-primary)] text-white text-sm px-5 py-2.5 rounded-2xl shadow-lg relative whitespace-nowrap">
+                  <span className="font-medium">✨ 로그인하고 내 리포트 확인하기!</span>
+                  <div
+                    className="absolute -right-[5px] top-1/2 -translate-y-1/2 
+                        w-0 h-0 border-t-[6px] border-b-[6px] border-l-[6px] 
+                        border-transparent border-l-[var(--color-primary)]"
+                  />
+                </div>
+              </div>
+              <button
+                onClick={handleNaverLogin}
+                className={`
+                ${commonButtonClass}
+                px-6 py-2 rounded-full 
+                border border-[var(--color-primary)]
+                text-[var(--color-primary)] text-sm font-bold cursor-pointer
+              `}
+                draggable={false}
+                onDragStart={(e) => e.preventDefault()}
+              >
+                로그인
+              </button>
+            </div>
           )}
         </div>
       </header>


### PR DESCRIPTION
## 📌 작업 내용

> 무엇을 구현/수정했는지 간단 요약

헤더 영역에 리포트 기능을 강조할 수 있도록 말풍선 코멘트 영역 추가

## 🔍 주요 변경 사항
### 로그인 버튼 옆 코멘트 추가
- 말풍선을 위, 아래로 움직여서 강조하도록 구성
- 위/아래로 움직일때마다 그라데이션 효과 추가 

### 메인페이지 띄어쓰기 수정
- 혜린님께서 부탁하신 마지막 멘트 띄어쓰기 추가했습니다.(아래 영상 참고)

### 헤더 프로필 이미지 변경
- 기본 이미지를 리포트 이미지와 프로필을 맞추기 위해 헤더 이미지를 변경했습니다.

## 🧪 테스트 방법

> 리뷰어가 해당 과정만 보고 테스트가 가능하도록 자세히 작성해주세요.

- 메인페이지에서 가장 하단에 띄어쓰기가 잘 적용되었는지 확인
- 퀴즈 목록 페이지에서 헤더 확인 후, 비회원 로그인 시 말풍선 적용 유무 확인
- 로그인 시, 말풍선이 사라지는지 확인
- 로그인 후, 헤더의 기본 이미지 변경 여부 확인

## ⚠️ 리뷰 시 참고 사항

## 👀 결과 화면

> 스크린샷 (필요시)


https://github.com/user-attachments/assets/96b7c25f-1019-4ea9-9fe7-be86cd87e3dd


## 📝 관련 이슈

> (예시) closes #<>

closes #262 